### PR TITLE
Endret loglevel fra error til info

### DIFF
--- a/oidc-spring-support/src/main/java/no/nav/security/spring/oidc/validation/interceptor/OIDCTokenControllerHandlerInterceptor.java
+++ b/oidc-spring-support/src/main/java/no/nav/security/spring/oidc/validation/interceptor/OIDCTokenControllerHandlerInterceptor.java
@@ -119,7 +119,7 @@ public class OIDCTokenControllerHandlerInterceptor implements HandlerInterceptor
         if (validationContext.hasValidToken()) {
             return true;
         }
-        logger.error("no token found in validation context");
+        logger.info("no token found in validation context");
         throw new OIDCUnauthorizedException("Authorization token required");
     }
 
@@ -136,7 +136,7 @@ public class OIDCTokenControllerHandlerInterceptor implements HandlerInterceptor
                 throw new OIDCUnauthorizedException("Authorization token not authorized");
             }
             if (!containsRequiredClaims(tokenClaims, claims)) {
-                logger.error("token does not contain all annotated claims");
+                logger.info("token does not contain all annotated claims");
                 throw new OIDCUnauthorizedException("Authorization token not authorized");
             }
         }


### PR DESCRIPTION
Endret loglevel fra error til info. Det er ikke en applikasjonsfeil som vi må agere på at det ikke er med et token i en request. Vi bruker Grafana til å sende alerts hvis det logges error i applikasjonene våre. Det at det ikke er med et token i en request, eller at det ikke tokenet inneholder alt det kanskje burde, er ikke en feil som vi må agere på. Det er sånt som skjer hundrevis av ganger hver dag, og det er helt greit.
