### PR TITLE
Unannotated RestControllers should throw a server error

### DIFF
--- a/token-validation-core/src/main/java/no/nav/security/token/support/core/validation/JwtTokenAnnotationHandler.java
+++ b/token-validation-core/src/main/java/no/nav/security/token/support/core/validation/JwtTokenAnnotationHandler.java
@@ -31,7 +31,7 @@ public class JwtTokenAnnotationHandler {
         this.tokenValidationContextHolder = tokenValidationContextHolder;
     }
 
-    public boolean assertValidAnnotation(Method method){
+    public boolean assertValidAnnotation(Method method) throws AnnotationRequiredException {
         Annotation annotation = getAnnotation(method, Arrays.asList(ProtectedWithClaims.class, Protected.class, Unprotected.class));
         if (annotation == null) {
             throw new AnnotationRequiredException("Server misconfigured - controller/method ["

--- a/token-validation-core/src/test/java/no/nav/security/token/support/core/configuration/MultiIssuerConfigurationTest.java
+++ b/token-validation-core/src/test/java/no/nav/security/token/support/core/configuration/MultiIssuerConfigurationTest.java
@@ -1,5 +1,6 @@
 package no.nav.security.token.support.core.configuration;
 
+import com.nimbusds.jose.util.DefaultResourceRetriever;
 import lombok.extern.slf4j.Slf4j;
 import no.nav.security.token.support.core.IssuerMockWebServer;
 import org.junit.jupiter.api.AfterEach;
@@ -34,7 +35,6 @@ class MultiIssuerConfigurationTest {
 
     @Test
     void getIssuerConfiguration() {
-
         IssuerProperties issuerProperties = new IssuerProperties(discoveryUrl, List.of("audience1"));
         String issuerName = "issuer1";
         MultiIssuerConfiguration multiIssuerConfiguration =
@@ -44,7 +44,6 @@ class MultiIssuerConfigurationTest {
 
     @Test
     void getIssuerConfigurationWithProxy() {
-
         IssuerProperties issuerProperties = new IssuerProperties(discoveryUrl, List.of("audience1"));
         issuerProperties.setProxyUrl(proxyUrl);
         String issuerName = "issuer1";
@@ -53,9 +52,9 @@ class MultiIssuerConfigurationTest {
 
         assertThatMultiIssuerConfigurationIsPopulatedFromMetadata(issuerName, multiIssuerConfiguration);
         IssuerConfiguration config = multiIssuerConfiguration.getIssuer(issuerName).orElse(null);
-
-
-        System.out.println("proxy: " + ((ProxyAwareResourceRetriever) config.getResourceRetriever()).getProxy());
+        assertThat(config).isNotNull();
+        assertThat(config.getResourceRetriever()).isInstanceOf(DefaultResourceRetriever.class);
+        assertThat(((DefaultResourceRetriever) config.getResourceRetriever()).getProxy()).isNotNull();
     }
 
     private void assertThatMultiIssuerConfigurationIsPopulatedFromMetadata(String issuerName,

--- a/token-validation-spring/src/main/java/no/nav/security/token/support/spring/validation/interceptor/JwtTokenHandlerInterceptor.java
+++ b/token-validation-spring/src/main/java/no/nav/security/token/support/spring/validation/interceptor/JwtTokenHandlerInterceptor.java
@@ -1,10 +1,13 @@
 package no.nav.security.token.support.spring.validation.interceptor;
 
+import no.nav.security.token.support.core.exceptions.AnnotationRequiredException;
 import no.nav.security.token.support.core.validation.JwtTokenAnnotationHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.annotation.AnnotationAttributes;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.ModelAndView;
 
@@ -29,8 +32,7 @@ public class JwtTokenHandlerInterceptor implements HandlerInterceptor {
             if (ignoreConfig == null) {
                 ignoreConfig = new String[0];
             }
-        }
-        else {
+        } else {
             // nothing explicitly configured to be ignored, intercept everything
             ignoreConfig = new String[0];
         }
@@ -45,6 +47,10 @@ public class JwtTokenHandlerInterceptor implements HandlerInterceptor {
             }
             try {
                 return jwtTokenAnnotationHandler.assertValidAnnotation(handlerMethod.getMethod());
+            } catch (AnnotationRequiredException e) {
+                logger.error("received AnnotationRequiredException from JwtTokenAnnotationHandler. return " +
+                    "status={}", HttpStatus.NOT_IMPLEMENTED, e);
+                throw new ResponseStatusException(HttpStatus.NOT_IMPLEMENTED, "endpoint not accessible");
             } catch (Exception e) {
                 throw new JwtTokenUnauthorizedException(e);
             }

--- a/token-validation-spring/src/test/java/no/nav/security/token/support/spring/validation/interceptor/JwtTokenHandlerInterceptorTest.java
+++ b/token-validation-spring/src/test/java/no/nav/security/token/support/spring/validation/interceptor/JwtTokenHandlerInterceptorTest.java
@@ -14,15 +14,19 @@ import no.nav.security.token.support.core.validation.JwtTokenAnnotationHandler;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.annotation.AnnotationAttributes;
+import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -56,8 +60,9 @@ class JwtTokenHandlerInterceptorTest {
     @Test
     void notAnnotatedShouldThrowException() {
         HandlerMethod handlerMethod = handlerMethod(new NotAnnotatedClass(), "test");
-        assertThrows(JwtTokenUnauthorizedException.class,
-            () -> interceptor.preHandle(request, response, handlerMethod));
+        assertThatExceptionOfType(ResponseStatusException.class).isThrownBy(
+            () -> interceptor.preHandle(request, response, handlerMethod))
+            .withMessageContaining(HttpStatus.NOT_IMPLEMENTED.toString());
     }
 
     @Test


### PR DESCRIPTION
* resolve #30 by handling missing annotations as a separate exception, returning 501 NOT_IMPLEMENTED
