### PR TITLE
Look for annotations more robustly

### DIFF
--- a/token-validation-core/src/main/java/no/nav/security/token/support/core/validation/JwtTokenAnnotationHandler.java
+++ b/token-validation-core/src/main/java/no/nav/security/token/support/core/validation/JwtTokenAnnotationHandler.java
@@ -62,7 +62,7 @@ public class JwtTokenAnnotationHandler {
         }
     }
 
-    private Annotation getAnnotation(Method method, List<Class<? extends Annotation>> types) {
+    protected Annotation getAnnotation(Method method, List<Class<? extends Annotation>> types) {
         Annotation annotation = findAnnotation(method.getAnnotations(), types);
         if (annotation != null) {
             log.debug("method " + method + " marked @{}", annotation.annotationType());

--- a/token-validation-spring/src/main/java/no/nav/security/token/support/spring/EnableJwtTokenValidationConfiguration.java
+++ b/token-validation-spring/src/main/java/no/nav/security/token/support/spring/EnableJwtTokenValidationConfiguration.java
@@ -35,6 +35,7 @@ import no.nav.security.token.support.core.context.TokenValidationContextHolder;
 import no.nav.security.token.support.filter.JwtTokenValidationFilter;
 import no.nav.security.token.support.spring.validation.interceptor.BearerTokenClientHttpRequestInterceptor;
 import no.nav.security.token.support.spring.validation.interceptor.JwtTokenHandlerInterceptor;
+import no.nav.security.token.support.spring.validation.interceptor.SpringJwtTokenAnnotationHandler;
 
 @Configuration
 @EnableConfigurationProperties(MultiIssuerProperties.class)
@@ -89,7 +90,7 @@ public class EnableJwtTokenValidationConfiguration implements WebMvcConfigurer, 
 
 	@Bean
 	public JwtTokenValidationFilter tokenValidationFilter(MultiIssuerConfiguration config, TokenValidationContextHolder tokenValidationContextHolder) {
-		return new JwtTokenValidationFilter(new JwtTokenValidationHandler(config), tokenValidationContextHolder);
+        return new JwtTokenValidationFilter(new JwtTokenValidationHandler(config), tokenValidationContextHolder);
 
 	}
 
@@ -103,7 +104,7 @@ public class EnableJwtTokenValidationConfiguration implements WebMvcConfigurer, 
 	public JwtTokenHandlerInterceptor getControllerInterceptor() {
 		logger.debug("registering OIDC token controller handler interceptor");
         return new JwtTokenHandlerInterceptor(enableOIDCTokenValidation,
-                new JwtTokenAnnotationHandler(new SpringTokenValidationContextHolder()));
+                new SpringJwtTokenAnnotationHandler(new SpringTokenValidationContextHolder()));
 	}
 
 

--- a/token-validation-spring/src/main/java/no/nav/security/token/support/spring/validation/interceptor/SpringJwtTokenAnnotationHandler.java
+++ b/token-validation-spring/src/main/java/no/nav/security/token/support/spring/validation/interceptor/SpringJwtTokenAnnotationHandler.java
@@ -1,0 +1,43 @@
+package no.nav.security.token.support.spring.validation.interceptor;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.springframework.core.annotation.AnnotationUtils;
+
+import no.nav.security.token.support.core.context.TokenValidationContextHolder;
+import no.nav.security.token.support.core.validation.JwtTokenAnnotationHandler;
+
+public class SpringJwtTokenAnnotationHandler extends JwtTokenAnnotationHandler {
+
+
+    public SpringJwtTokenAnnotationHandler(TokenValidationContextHolder tokenValidationContextHolder) {
+        super(tokenValidationContextHolder);
+    }
+
+    @Override
+    protected Annotation getAnnotation(Method method, List<Class<? extends Annotation>> types) {
+       return Optional.ofNullable(scanAnnotation(method, types))
+               .orElseGet(() -> scanAnnotation(method.getDeclaringClass(), types));
+    }
+
+    private static Annotation scanAnnotation(Method m, List<Class<? extends Annotation>> types) {
+        return types.stream()
+                .map(t -> AnnotationUtils.findAnnotation(m, t))
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private static Annotation scanAnnotation(Class<?> clazz, List<Class<? extends Annotation>> types) {
+        return types.stream()
+                .map(t -> AnnotationUtils.findAnnotation(clazz, t))
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElse(null);
+    }
+
+}

--- a/token-validation-spring/src/test/java/no/nav/security/token/support/spring/validation/interceptor/MetaAnnotations.java
+++ b/token-validation-spring/src/test/java/no/nav/security/token/support/spring/validation/interceptor/MetaAnnotations.java
@@ -1,0 +1,32 @@
+package no.nav.security.token.support.spring.validation.interceptor;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.RetentionPolicy;
+import no.nav.security.token.support.core.api.Protected;
+import no.nav.security.token.support.core.api.ProtectedWithClaims;
+import no.nav.security.token.support.core.api.Unprotected;
+
+@Protected
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+
+@interface ProtectedMeta {
+
+}
+
+@ProtectedWithClaims(issuer = "issuer1", claimMap = { "acr=Level4" })
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+
+ @interface ProtectedWithClaimsMeta {
+
+}
+@Unprotected
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+
+ @interface UnprotectedMeta {
+
+ }


### PR DESCRIPTION
The _JwtTokenAnnotationHandler_ inspects the handler method of an incoming rest call in order to determine which (if any) annotations of type _Protected_, _ProtectedWithClaims_ or _Protected_  are present, and thus need to be honoured.  The currrent implementation only inspects the _direct/immediate_ annotations on the method or the class. This makes it impossible to group common annotations into a meta-annotation e.g like 
```
@RestController
@ProtectedWithClaims(issuer = "selvbetjening", claimMap = { "acr=Level4" })
@Target(ElementType.TYPE)
@Retention(RetentionPolicy.RUNTIME)

public @interface ProtectedRestController {

}
```
It also makes it impossible for these annotations to be detected if they are present on an interface or a superclass. This PR creates a subclass _SpringJwtTokenAnnotationHandler_ that overrides the _getAnnotations_ method. This methods then uses a Spring utility class [_AnnotationsUtils_](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/core/annotation/AnnotationUtils.html) to detect annotations on the method/class also if they are provided via meta-annotations or superclasses/interfaces. 
Note that this will only work when using Spring Boot. Ideally this extension should be on the _JwtTokenAnnotationHandler_ itself, but implementing this using JDK-methods only is quite a mouthful, and left as an exercise to the maintainers.  :-)