### PR TITLE
[token-client-*]: Support well-known url if token endpoint url is not set

### DIFF
--- a/token-client-core/src/main/java/no/nav/security/token/support/client/core/ClientProperties.java
+++ b/token-client-core/src/main/java/no/nav/security/token/support/client/core/ClientProperties.java
@@ -1,8 +1,13 @@
 package no.nav.security.token.support.client.core;
 
+import com.nimbusds.jose.util.DefaultResourceRetriever;
+import com.nimbusds.jose.util.ResourceRetriever;
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.as.AuthorizationServerMetadata;
 import lombok.*;
 
 import javax.validation.constraints.NotNull;
+import java.io.IOException;
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
@@ -13,7 +18,7 @@ import java.util.function.Supplier;
 @Getter
 @ToString
 @EqualsAndHashCode
-@Builder(toBuilder = true)
+
 public class ClientProperties {
 
     private static final List<OAuth2GrantType> GRANT_TYPES = List.of(
@@ -31,20 +36,46 @@ public class ClientProperties {
     private final ClientAuthenticationProperties authentication;
     private final URI resourceUrl;
     private final TokenExchangeProperties tokenExchange;
+    private final URI wellKnownUrl;
+    private AuthorizationServerMetadata authorizationServerMetadata;
+    private ResourceRetriever resourceRetriever;
 
-    public ClientProperties(@NotNull URI tokenEndpointUrl,
+    @Builder(toBuilder = true)
+    public ClientProperties(URI tokenEndpointUrl,
+                            URI wellKnownUrl,
                             @NotNull OAuth2GrantType grantType,
                             List<String> scope,
                             @NotNull ClientAuthenticationProperties authentication,
                             URI resourceUrl,
                             TokenExchangeProperties tokenExchange
     ) {
-        this.tokenEndpointUrl = tokenEndpointUrl;
+        this.wellKnownUrl = wellKnownUrl;
+
+        if(tokenEndpointUrl != null){
+            this.tokenEndpointUrl = tokenEndpointUrl;
+        } else {
+            this.resourceRetriever = new DefaultResourceRetriever();
+            this.authorizationServerMetadata = retrieveAuthorizationServerMetadata();
+            this.tokenEndpointUrl = this.authorizationServerMetadata.getTokenEndpointURI();
+        }
         this.grantType = getSupported(grantType);
         this.scope = Optional.ofNullable(scope).orElse(Collections.emptyList());
         this.authentication = authentication;
         this.resourceUrl = resourceUrl;
         this.tokenExchange = tokenExchange;
+    }
+
+    private AuthorizationServerMetadata retrieveAuthorizationServerMetadata(){
+        if (wellKnownUrl == null) {
+            throw new OAuth2ClientException("wellKnownUrl cannot be null, please check your configuration.");
+        }
+        try {
+            return AuthorizationServerMetadata.parse(
+                resourceRetriever.retrieveResource(wellKnownUrl.toURL()).getContent()
+            );
+        } catch (ParseException | IOException e) {
+            throw new OAuth2ClientException("received exception when retrieving metadata from url " + wellKnownUrl, e);
+        }
     }
 
     private static OAuth2GrantType getSupported(OAuth2GrantType oAuth2GrantType) {

--- a/token-client-core/src/test/java/no/nav/security/token/support/client/core/ClientPropertiesTest.java
+++ b/token-client-core/src/test/java/no/nav/security/token/support/client/core/ClientPropertiesTest.java
@@ -1,47 +1,96 @@
 package no.nav.security.token.support.client.core;
 
-
 import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.net.URI;
 import java.util.List;
 
+import static no.nav.security.token.support.client.core.TestUtils.jsonResponse;
+import static no.nav.security.token.support.client.core.TestUtils.withMockServer;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 class ClientPropertiesTest {
 
-    @Test
-    void validAuthenticationProperties() {
-        createInstanceWith(OAuth2GrantType.JWT_BEARER);
-        createInstanceWith(OAuth2GrantType.CLIENT_CREDENTIALS);
+    private String wellKnownJson =
+        "{\n" +
+            "  \"issuer\" : \"https://someissuer\",\n" +
+            "  \"token_endpoint\" : \"https://someissuer/token\",\n" +
+            "  \"jwks_uri\" : \"https://someissuer/jwks\",\n" +
+            "  \"grant_types_supported\" : [ \"urn:ietf:params:oauth:grant-type:token-exchange\" ],\n" +
+            "  \"token_endpoint_auth_methods_supported\" : [ \"private_key_jwt\" ],\n" +
+            "  \"token_endpoint_auth_signing_alg_values_supported\" : [ \"RS256\" ],\n" +
+            "  \"subject_types_supported\" : [ \"public\" ]\n" +
+            "}";
+
+    private static ClientProperties clientPropertiesFromWellKnown(URI wellKnownUrl) {
+        return new ClientProperties(
+            null,
+            wellKnownUrl,
+            OAuth2GrantType.CLIENT_CREDENTIALS,
+            List.of("scope1", "scope2"),
+            clientAuth(),
+            null,
+            tokenExchange()
+        );
     }
 
-    @Test
-    void invalidAuthenticationProperties() {
-        assertThatExceptionOfType(IllegalArgumentException.class)
-            .isThrownBy(() -> createInstanceWith(new OAuth2GrantType("somegrantNotSupported")));
-        assertThatExceptionOfType(IllegalArgumentException.class)
-            .isThrownBy(() -> ClientProperties.builder()
-                .grantType(new OAuth2GrantType("somegrantNotSupported"))
-                .build());
+    private static ClientAuthenticationProperties clientAuth() {
+        return new ClientAuthenticationProperties(
+            "client",
+            ClientAuthenticationMethod.CLIENT_SECRET_BASIC,
+            "secret",
+            null);
     }
 
-    private static void createInstanceWith(OAuth2GrantType grantType) {
-        new ClientProperties(
+    private static ClientProperties.TokenExchangeProperties tokenExchange() {
+        return new ClientProperties.TokenExchangeProperties(
+            "aud1",
+            null
+        );
+    }
+
+    private static ClientProperties clientPropertiesFromGrantType(OAuth2GrantType grantType) {
+        return new ClientProperties(
             URI.create("http://token"),
+            null,
             grantType,
             List.of("scope1", "scope2"),
-            new ClientAuthenticationProperties(
-                "client",
-                ClientAuthenticationMethod.CLIENT_SECRET_BASIC,
-                "secret",
-                null),
+            clientAuth(),
             null,
-            new ClientProperties.TokenExchangeProperties(
-                "",
-                ""
-            )
+            tokenExchange()
         );
+    }
+
+    @Test
+    void validGrantTypes() {
+        clientPropertiesFromGrantType(OAuth2GrantType.JWT_BEARER);
+        clientPropertiesFromGrantType(OAuth2GrantType.CLIENT_CREDENTIALS);
+        clientPropertiesFromGrantType(OAuth2GrantType.TOKEN_EXCHANGE);
+    }
+
+    @Test
+    void invalidGrantTypes() {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> clientPropertiesFromGrantType(new OAuth2GrantType("somegrantNotSupported")));
+    }
+
+    @Test
+    void ifWellKnownUrlIsNotNullShouldRetrieveMetadataAndSetTokenEndpoint() throws IOException {
+        withMockServer(
+            s -> {
+                s.enqueue(jsonResponse(wellKnownJson));
+                clientPropertiesFromWellKnown(s.url("/well-known").uri());
+            }
+        );
+    }
+
+    @Test
+    void incorrectWellKnownUrlShouldThrowException(){
+        assertThatExceptionOfType(OAuth2ClientException.class)
+            .isThrownBy(() ->
+                clientPropertiesFromWellKnown(URI.create("http://localhost:1234/notfound"))
+            );
     }
 }

--- a/token-client-core/src/test/java/no/nav/security/token/support/client/core/TestUtils.java
+++ b/token-client-core/src/test/java/no/nav/security/token/support/client/core/TestUtils.java
@@ -5,8 +5,10 @@ import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.PlainJWT;
 import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
 import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
 
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URLEncoder;
@@ -15,6 +17,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.*;
+import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -54,6 +57,13 @@ public class TestUtils {
                 .audience("audience1")
                 .build())
             .build();
+    }
+
+    public static void withMockServer(Consumer<MockWebServer> test) throws IOException {
+        MockWebServer server = new MockWebServer();
+        server.start();
+        test.accept(server);
+        server.shutdown();
     }
 
     public static MockResponse jsonResponse(String json) {

--- a/token-client-spring/src/test/java/no/nav/security/token/support/client/spring/oauth2/ClientConfigurationPropertiesTestWithWellKnownUrl.java
+++ b/token-client-spring/src/test/java/no/nav/security/token/support/client/spring/oauth2/ClientConfigurationPropertiesTestWithWellKnownUrl.java
@@ -1,0 +1,85 @@
+package no.nav.security.token.support.client.spring.oauth2;
+
+import no.nav.security.token.support.client.core.ClientAuthenticationProperties;
+import no.nav.security.token.support.client.core.ClientProperties;
+import no.nav.security.token.support.client.spring.ClientConfigurationProperties;
+import no.nav.security.token.support.core.context.TokenValidationContextHolder;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.web.client.RestTemplateAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.support.TestPropertySourceUtils;
+
+import java.io.IOException;
+
+import static no.nav.security.token.support.client.spring.oauth2.TestUtils.jsonResponse;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(classes = {OAuth2ClientConfiguration.class, RestTemplateAutoConfiguration.class})
+@ContextConfiguration(initializers = ClientConfigurationPropertiesTestWithWellKnownUrl.RandomPortInitializer.class)
+@ActiveProfiles("test-withwellknownurl")
+class ClientConfigurationPropertiesTestWithWellKnownUrl {
+
+    @Autowired
+    private MockWebServer mockWebServer;
+
+    @MockBean
+    private TokenValidationContextHolder tokenValidationContextHolder;
+
+    @Autowired
+    private ClientConfigurationProperties clientConfigurationProperties;
+
+    @Test
+    void testClientConfigIsValid() {
+        assertThat(clientConfigurationProperties).isNotNull();
+        assertThat(clientConfigurationProperties.getRegistration()).isNotNull();
+        ClientProperties clientProperties =
+            clientConfigurationProperties.getRegistration().values().stream().findFirst().orElse(null);
+        assertThat(clientProperties).isNotNull();
+        ClientAuthenticationProperties auth = clientProperties.getAuthentication();
+        assertThat(auth).isNotNull();
+        assertThat(auth.getClientAuthMethod()).isNotNull();
+        assertThat(auth.getClientId()).isNotNull();
+        assertThat(auth.getClientRsaKey()).isNotNull();
+        assertThat(clientProperties.getTokenEndpointUrl()).isNotNull();
+        assertThat(clientProperties.getGrantType().getValue()).isNotNull();
+    }
+
+    public static class RandomPortInitializer
+        implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+        private String wellKnown = "{\n" +
+            "  \"issuer\" : \"https://someissuer\",\n" +
+            "  \"token_endpoint\" : \"https://someissuer/token\",\n" +
+            "  \"jwks_uri\" : \"https://someissuer/jwks\",\n" +
+            "  \"grant_types_supported\" : [ \"urn:ietf:params:oauth:grant-type:token-exchange\" ],\n" +
+            "  \"token_endpoint_auth_methods_supported\" : [ \"private_key_jwt\" ],\n" +
+            "  \"token_endpoint_auth_signing_alg_values_supported\" : [ \"RS256\" ],\n" +
+            "  \"subject_types_supported\" : [ \"public\" ]\n" +
+            "}";
+
+
+        @Override
+        public void initialize(ConfigurableApplicationContext applicationContext) {
+            GenericApplicationContext ctx = (GenericApplicationContext) applicationContext;
+            MockWebServer server = new MockWebServer();
+            ctx.registerBean("mockWebServer", MockWebServer.class, () -> server);
+            try {
+                server.start();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            TestPropertySourceUtils.addInlinedPropertiesToEnvironment(applicationContext,
+                "mockwebserver.port=" + server.getPort());
+            server.enqueue(jsonResponse(wellKnown));
+        }
+    }
+}
+

--- a/token-client-spring/src/test/java/no/nav/security/token/support/client/spring/oauth2/TestUtils.java
+++ b/token-client-spring/src/test/java/no/nav/security/token/support/client/spring/oauth2/TestUtils.java
@@ -1,10 +1,25 @@
 package no.nav.security.token.support.client.spring.oauth2;
 
 import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 
+import java.io.IOException;
+import java.util.function.Consumer;
+
 class TestUtils {
+
+    static void withMockServer(int port, Consumer<MockWebServer> test) throws IOException{
+        MockWebServer server = new MockWebServer();
+        server.start(port);
+        test.accept(server);
+        server.shutdown();
+    }
+
+    static void withMockServer(Consumer<MockWebServer> test) throws IOException {
+        withMockServer(0, test);
+    }
 
     static MockResponse jsonResponse(String json) {
         return new MockResponse()

--- a/token-client-spring/src/test/resources/application-test-withwellknownurl.yml
+++ b/token-client-spring/src/test/resources/application-test-withwellknownurl.yml
@@ -1,0 +1,13 @@
+no.nav.security.jwt.client:
+  registration:
+    example1-token-exchange1:
+      well-known-url: http://localhost:${mockwebserver.port}/well-known
+      grant-type: urn:ietf:params:oauth:grant-type:token-exchange
+      authentication:
+        client-id: cluster:namespace:app1
+        client-jwk: src/test/resources/jwk.json
+        client-auth-method: private_key_jwt
+      token-exchange:
+        audience: cluster:namespace:app2
+
+logging.level.okhttp3: DEBUG


### PR DESCRIPTION
* add new property `well-known-url:` to `no.nav.security.jwt.client.registration.[somename]`
* will populate `token-endpoint-url` with value retrieved from metadata