### PR TITLE
Make the token claim set configurable in MockLoginController

### DIFF
--- a/token-validation-spring-test/src/main/java/no/nav/security/token/support/spring/test/MockLoginController.java
+++ b/token-validation-spring-test/src/main/java/no/nav/security/token/support/spring/test/MockLoginController.java
@@ -49,42 +49,42 @@ public class MockLoginController {
                 )
             ).serialize();
 
-        Cookie cookie = new Cookie(cookieName, token);
-        cookie.setDomain("localhost");
-        cookie.setPath("/");
-        response.addCookie(cookie);
-        if (redirect != null) {
-            response.sendRedirect(redirect);
-            return null;
-        }
-        return cookie;
+        return createCookieAndAddToResponse(
+            response,
+            cookieName,
+            token,
+            redirect
+        );
     }
 
     @Unprotected
-    @PostMapping("/cookie")
-    public Cookie addCoaaokie(
-        @RequestParam(value = "issuerId") String issuerId,
-        @RequestParam(value = "audience") String audience,
-        @RequestParam(value = "subject", defaultValue = "12345678910") String subject,
+    @PostMapping("/cookie/{issuerId}")
+    public Cookie addCookie(
+        @PathVariable(value = "issuerId") String issuerId,
         @RequestParam(value = "cookiename", defaultValue = "localhost-idtoken") String cookieName,
         @RequestParam(value = "redirect", required = false) String redirect,
-        @RequestParam(value = "expiry", required = false) String expiry,
         @RequestBody Map<String, Object> claims,
         HttpServletResponse response
     ) throws IOException {
-        String token =
-            mockOAuth2Server.issueToken(
-                issuerId,
-                MockLoginController.class.getSimpleName(),
-                new DefaultOAuth2TokenCallback(
-                    issuerId,
-                    subject,
-                    List.of(audience),
-                    claims != null ? claims : Collections.emptyMap(),
-                    expiry != null ? Long.parseLong(expiry) : 3600
-                )
-            ).serialize();
+        String token = mockOAuth2Server.anyToken(
+            mockOAuth2Server.issuerUrl(issuerId),
+            claims
+        ).serialize();
 
+        return createCookieAndAddToResponse(
+            response,
+            cookieName,
+            token,
+            redirect
+        );
+    }
+
+    private Cookie createCookieAndAddToResponse(
+        HttpServletResponse response,
+        String cookieName,
+        String token,
+        String redirect
+    ) throws IOException {
         Cookie cookie = new Cookie(cookieName, token);
         cookie.setDomain("localhost");
         cookie.setPath("/");
@@ -95,5 +95,4 @@ public class MockLoginController {
         }
         return cookie;
     }
-
 }

--- a/token-validation-spring-test/src/main/java/no/nav/security/token/support/spring/test/MockLoginController.java
+++ b/token-validation-spring-test/src/main/java/no/nav/security/token/support/spring/test/MockLoginController.java
@@ -71,17 +71,17 @@ public class MockLoginController {
     }
 
     private Map<String, Object> extractClaims(
-        Map<String, String> allClaims,
+        Map<String, String> allParameters,
         List<String> groups,
-        String... ignoredClaims
+        String... ignoredParameters
     ) {
-        Map<String, Object> claimsWithoutDefaults = allClaims
+        Map<String, Object> claimsWithoutDefaults = allParameters
             .keySet()
             .stream()
-            .filter(key -> !Arrays.asList(ignoredClaims).contains(key))
+            .filter(key -> !Arrays.asList(ignoredParameters).contains(key))
             .collect(Collectors.toMap(
                 key -> key,
-                key -> allClaims.get(key)
+                key -> allParameters.get(key)
             ));
         if (groups != null) {
             claimsWithoutDefaults.put("groups", groups);

--- a/token-validation-spring-test/src/test/java/no/nav/security/token/support/spring/test/TestApplication.java
+++ b/token-validation-spring-test/src/test/java/no/nav/security/token/support/spring/test/TestApplication.java
@@ -5,6 +5,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@EnableMockOAuth2Server
 @EnableAutoConfiguration
 class TestApplication {
     public static void main(String[] args) {

--- a/token-validation-spring-test/src/test/java/no/nav/security/token/support/spring/test/TestApplication.java
+++ b/token-validation-spring-test/src/test/java/no/nav/security/token/support/spring/test/TestApplication.java
@@ -5,7 +5,6 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@EnableMockOAuth2Server
 @EnableAutoConfiguration
 class TestApplication {
     public static void main(String[] args) {


### PR DESCRIPTION
The controller as is _only_ returns tokens with `acr=Level4` as the only custom claim.
My team and I are in need of two additional claims - the `groups` claim (which is a list of strings) and the `NAVident` claim. One way of doing this would be to just add the claims to the controller as input parameters, but I can imagine these won't be the only custom claims people would need in the future. Also the `acr` claim should be customizable.

With this PR, consumers can set claims by passing them as request parameters - i.e. `/cookie?NAVident=Z123456&groups=111111` would satisfy my needs.

I am not really satisfied with the way I use ´allParameters´ in the code though, filtering out every known parameter to get to the claims. Suggestions are appreciated.