### PR TITLE
Make token validation filter order configurable with default value Or…

### DIFF
--- a/token-validation-core/src/main/java/no/nav/security/token/support/core/JwtTokenConstants.java
+++ b/token-validation-core/src/main/java/no/nav/security/token/support/core/JwtTokenConstants.java
@@ -6,6 +6,7 @@ public class JwtTokenConstants {
     public static final String COOKIE_NAME = "%s-idtoken";
     public static final String AUTHORIZATION_HEADER = "Authorization";
     public static final String EXPIRY_THRESHOLD_ENV_PROPERTY = "no.nav.security.jwt.expirythreshold";
+    public static final String TOKEN_VALIDATION_FILTER_ORDER_PROPERTY = "no.nav.security.jwt.tokenvalidationfilter.order";
     public static final String TOKEN_EXPIRES_SOON_HEADER = "x-token-expires-soon";
 
     public static String getDefaultCookieName(String issuer) {

--- a/token-validation-spring/src/main/java/no/nav/security/token/support/spring/EnableJwtTokenValidationConfiguration.java
+++ b/token-validation-spring/src/main/java/no/nav/security/token/support/spring/EnableJwtTokenValidationConfiguration.java
@@ -41,7 +41,7 @@ import no.nav.security.token.support.spring.validation.interceptor.SpringJwtToke
 @EnableConfigurationProperties(MultiIssuerProperties.class)
 public class EnableJwtTokenValidationConfiguration implements WebMvcConfigurer, EnvironmentAware, ImportAware {
 
-	private final Logger logger = LoggerFactory.getLogger(EnableJwtTokenValidationConfiguration.class);
+    private final Logger logger = LoggerFactory.getLogger(EnableJwtTokenValidationConfiguration.class);
 
 	private Environment env;
 
@@ -110,7 +110,10 @@ public class EnableJwtTokenValidationConfiguration implements WebMvcConfigurer, 
 
 	@Bean
 	@Qualifier("oidcTokenValidationFilterRegistrationBean")
-	public FilterRegistrationBean<JwtTokenValidationFilter> oidcTokenValidationFilterRegistrationBean(JwtTokenValidationFilter validationFilter) {
+	public FilterRegistrationBean<JwtTokenValidationFilter> oidcTokenValidationFilterRegistrationBean(JwtTokenValidationFilter validationFilter,
+                                                                                                      @Value("${" + JwtTokenConstants.TOKEN_VALIDATION_FILTER_ORDER_PROPERTY
+                                                                                                          + ":" + Ordered.HIGHEST_PRECEDENCE + "}")
+                                                                                                          Integer tokenValidationFilterOrder) {
 		logger.info("Registering validation filter");
 		final FilterRegistrationBean<JwtTokenValidationFilter> filterRegistration = new FilterRegistrationBean<>();
 		filterRegistration.setFilter(validationFilter);
@@ -118,7 +121,7 @@ public class EnableJwtTokenValidationConfiguration implements WebMvcConfigurer, 
 		filterRegistration
 				.setDispatcherTypes(EnumSet.of(DispatcherType.REQUEST, DispatcherType.FORWARD, DispatcherType.ASYNC));
 		filterRegistration.setAsyncSupported(true);
-		filterRegistration.setOrder(Ordered.HIGHEST_PRECEDENCE);
+		filterRegistration.setOrder(tokenValidationFilterOrder);
 		return filterRegistration;
 	}
 


### PR DESCRIPTION
…dered.HIGHEST_PRECEDENCE as before. This makes it possible to do header customization in clients before validation kicks in.

This is to enable a workaround to https://github.com/navikt/token-support/issues/139 without introducing a proxy outside of our application. The customization makes it possible to remove duplicates through a Filter before validation kicks in. 