### PR TITLE
deps, fix: nimbus upgrades and logging of potential missing dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,10 +58,10 @@
         <ktor.version>1.5.4</ktor.version>
         <kotlin.code.style>official</kotlin.code.style>
         <kotlin.version>1.5.10</kotlin.version>
-        <mock-oauth2-server.version>0.3.0.RC2</mock-oauth2-server.version>
+        <mock-oauth2-server.version>0.3.3</mock-oauth2-server.version>
         <groovy.version>3.0.8</groovy.version>
         <logback.version>1.2.3</logback.version>
-        <nimbus.jose.jwt.version>8.20.1</nimbus.jose.jwt.version>
+        <nimbus.jose.jwt.version>9.9.3</nimbus.jose.jwt.version>
         <kotest.version>4.6.0</kotest.version>
         <kotlin.compiler.jvmTarget>11</kotlin.compiler.jvmTarget>
     </properties>

--- a/token-validation-core/src/main/java/no/nav/security/token/support/core/validation/DefaultJwtTokenValidator.java
+++ b/token-validation-core/src/main/java/no/nav/security/token/support/core/validation/DefaultJwtTokenValidator.java
@@ -48,6 +48,10 @@ public class DefaultJwtTokenValidator implements JwtTokenValidator {
         try {
             token = JWTParser.parse(tokenString);
             get(token).validate(token, expectedNonce != null ? new Nonce(expectedNonce) : null);
+        } catch (NoSuchMethodError e) {
+            String msg = "Dependant method not found. Ensure that nimbus-jose-jwt and/or oauth2-oidc-sdk has versions >= 9.x (e.g. Spring Boot >= 2.5.0)";
+            LOG.error(msg, e);
+            throw new JwtTokenValidatorException(msg, e);
         } catch (Throwable t) {
             throw new JwtTokenValidatorException("Token validation failed", expiryDate(token), t);
         }


### PR DESCRIPTION
- bump `mock-oauth2-server` to 0.3.3
- bump `nimbus.jose.jwt.version` to 9.9.3
- log error for missing dependant method for easier debugging/remediation

Fixes #277, fixes #276 (hopefully)