### PR TITLE
bedre feilmelding ved ikke-annotert metode

### DIFF
--- a/token-validation-core/src/main/java/no/nav/security/token/support/core/exceptions/AnnotationRequiredException.java
+++ b/token-validation-core/src/main/java/no/nav/security/token/support/core/exceptions/AnnotationRequiredException.java
@@ -9,7 +9,7 @@ public class AnnotationRequiredException extends RuntimeException {
 
     public AnnotationRequiredException(Method method) {
         this("Server misconfigured - controller/method ["
-                + method.getClass().getName() + "." + method.getName()
+                + method.getDeclaringClass().getName() + "." + method.getName()
                 + "] not annotated @Unprotected, @Protected, @RequiredClaims or added to ignore list");
     }
 }


### PR DESCRIPTION
_method.getClass().getName()_ gir kun Method-klassens navn, altså _java.lang.reflect.Method_.
_method.getDeclaringClass().getName()_ gir klassen metoden er deklarert i, og gir bedre hjelp ved feilsøking. 