### PR TITLE
Støtt bruk av asterisk som claims-verdi i ProtectedWithClaims

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,8 +160,8 @@ This example shows
 - First method - An unprotected endpoint. No token is required to use this endpoint.
 - Second method - A protected endpoint. This endpoint will require a valid token from one of the configured issuers.
 - Third method - A protected endpoint. This endpoint will require a valid token from the "employee" or "manager" issuer.
-- Fourth method - A protected endpoint. This endpoint will require a valid token from the "manager" issuer and a claim where key is "acr" and value is "Level4" 
-
+- Fourth method - A protected endpoint. This endpoint will require a valid token from the "manager" issuer and a claim where key is "acr" and value is "Level4". 
+- Fifth method - A non-annotated endpoint. This endpoint will not be accessible from outside the server (will return a 501 NOT_IMPLEMENTED).
 ```java
 @Path("/rest")
 public class ProductResource {
@@ -197,6 +197,12 @@ public class ProductResource {
   @ProtectedWithClaims(issuer = "manager", claimMap = { "acr=Level4" })
   public void add(String id) {		
     return service.delete(id);   
+  }
+
+  @GET
+  @PATH("/product/{id}")
+  public void add(String id) {
+    return service.get(id);
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -158,9 +158,9 @@ new ResourceConfig()
 This example shows
 
 - First method - An unprotected endpoint. No token is required to use this endpoint.
-- Second method - A protected endpoint. This endpoint will require a valid token from the "employee" issuer. 
-- Third method - A protected endpoint. This endpoint will require a valid token from one of the configured issuers.
-- Fourth method - A non-annotated endpoint. This endpoint will not be accessible from outside the server (will return a 501 NOT_IMPLEMENTED). 
+- Second method - A protected endpoint. This endpoint will require a valid token from one of the configured issuers.
+- Third method - A protected endpoint. This endpoint will require a valid token from the "employee" or "manager" issuer.
+- Fourth method - A protected endpoint. This endpoint will require a valid token from the "manager" issuer and a claim where key is "acr" and value is "Level4" 
 
 ```java
 @Path("/rest")
@@ -181,6 +181,16 @@ public class ProductResource {
   public Product add(Product product) {		
     return service.create(product);
   }
+
+  @PUT
+  @PATH("/product")
+  @RequiredIssuers(value = {
+          ProtectedWithClaims(issuer = "employee"),
+          ProtectedWithClaims(issuer = "manager")
+  })
+  public Product add(Product product) {
+    return service.update(product);
+  }
 	
   @DELETE
   @PATH("/product/{id}")
@@ -188,9 +198,12 @@ public class ProductResource {
   public void add(String id) {		
     return service.delete(id);   
   }
-
 }
 ```
+
+The claimMap in **`@ProtectedWithClaims`** can contain entries where the expected value is an asterisk, e.g.: **`"acr=*"`**. This will require that the claim is present in the token, without regards to its value.
+
+
 ### token-validation-ktor
 
 See demo application in **`token-validation-ktor-demo`** for example configurations and setups.

--- a/token-validation-core/src/main/java/no/nav/security/token/support/core/api/ProtectedWithClaims.java
+++ b/token-validation-core/src/main/java/no/nav/security/token/support/core/api/ProtectedWithClaims.java
@@ -11,10 +11,11 @@ import java.lang.annotation.Target;
 @Target({ TYPE, METHOD })
 @Protected
 public @interface ProtectedWithClaims {
-		
+
 	String issuer();
 	/**
-	 * Required claims in token in key=value format
+	 * Required claims in token in key=value format.
+     * If the value is an asterisk (*), it checks that the required key is present.
 	 * @return array containing claims as key=value
 	 */
 	String[] claimMap() default {};

--- a/token-validation-core/src/main/java/no/nav/security/token/support/core/jwt/JwtTokenClaims.java
+++ b/token-validation-core/src/main/java/no/nav/security/token/support/core/jwt/JwtTokenClaims.java
@@ -53,13 +53,16 @@ public class JwtTokenClaims {
         if (claim == null) {
             return false;
         }
+        if (value.equals("*")) {
+            return true;
+        }
         if (claim instanceof String) {
             String claimAsString = (String) claim;
-            return claimAsString.equals(value) || value.equals("*");
+            return claimAsString.equals(value);
         }
         if (claim instanceof Collection<?>) {
             Collection<?> claimasList = (Collection<?>) claim;
-            return claimasList.contains(value) || (value.equals("*") && !claimasList.isEmpty());
+            return claimasList.contains(value);
         }
         return false;
     }

--- a/token-validation-core/src/main/java/no/nav/security/token/support/core/jwt/JwtTokenClaims.java
+++ b/token-validation-core/src/main/java/no/nav/security/token/support/core/jwt/JwtTokenClaims.java
@@ -55,11 +55,11 @@ public class JwtTokenClaims {
         }
         if (claim instanceof String) {
             String claimAsString = (String) claim;
-            return claimAsString.equals(value);
+            return claimAsString.equals(value) || value.equals("*");
         }
         if (claim instanceof Collection<?>) {
             Collection<?> claimasList = (Collection<?>) claim;
-            return claimasList.contains(value);
+            return claimasList.contains(value) || (value.equals("*") && !claimasList.isEmpty());
         }
         return false;
     }

--- a/token-validation-core/src/test/java/no/nav/security/token/support/core/jwt/JwtTokenClaimsTest.java
+++ b/token-validation-core/src/test/java/no/nav/security/token/support/core/jwt/JwtTokenClaimsTest.java
@@ -37,7 +37,7 @@ class JwtTokenClaimsTest {
         ).isTrue();
         assertThat(
             withClaim("emptyArrayClaim", List.of()).containsClaim("emptyArrayClaim", "*")
-        ).isFalse();
+        ).isTrue();
     }
 
     private JwtTokenClaims withClaim(String name, Object value) {

--- a/token-validation-core/src/test/java/no/nav/security/token/support/core/jwt/JwtTokenClaimsTest.java
+++ b/token-validation-core/src/test/java/no/nav/security/token/support/core/jwt/JwtTokenClaimsTest.java
@@ -14,11 +14,30 @@ class JwtTokenClaimsTest {
     @Test
     void containsClaimShouldHandleBothStringAndListClaim() {
         assertThat(
-            withClaim("arrayClaim", List.of("1","2")).containsClaim("arrayClaim", "1")
+            withClaim("arrayClaim", List.of("1", "2")).containsClaim("arrayClaim", "1")
         ).isTrue();
         assertThat(
             withClaim("stringClaim", "1").containsClaim("stringClaim", "1")
         ).isTrue();
+    }
+
+    @Test
+    void containsClaimShouldHandleAsterisk() {
+        assertThat(
+            withClaim("stringClaim", "1").containsClaim("stringClaim", "*")
+        ).isTrue();
+        assertThat(
+            withClaim("emptyStringClaim", "").containsClaim("emptyStringClaim", "*")
+        ).isTrue();
+        assertThat(
+            withClaim("nullStringClaim", null).containsClaim("nullStringClaim", "*")
+        ).isFalse();
+        assertThat(
+            withClaim("arrayClaim", List.of("1", "2")).containsClaim("arrayClaim", "*")
+        ).isTrue();
+        assertThat(
+            withClaim("emptyArrayClaim", List.of()).containsClaim("emptyArrayClaim", "*")
+        ).isFalse();
     }
 
     private JwtTokenClaims withClaim(String name, Object value) {


### PR DESCRIPTION
Usikker på om dette er en feature som er ønsket av flere, men mitt team har behov for dette. 
Et eksempel er at vi ønsker å sjekke om en token inneholder "NAVident", men vi bryr oss ikke om hva verdien er. 
