### PR TITLE
Endrer DefaultOAuth2HttpClient for å kunne extende den

### DIFF
--- a/token-client-spring/src/main/kotlin/no/nav/security/token/support/client/spring/oauth2/DefaultOAuth2HttpClient.kt
+++ b/token-client-spring/src/main/kotlin/no/nav/security/token/support/client/spring/oauth2/DefaultOAuth2HttpClient.kt
@@ -12,7 +12,7 @@ import org.springframework.util.LinkedMultiValueMap
 import org.springframework.web.client.HttpStatusCodeException
 import org.springframework.web.client.RestTemplate
 
-class DefaultOAuth2HttpClient(restTemplateBuilder: RestTemplateBuilder) : OAuth2HttpClient {
+open class DefaultOAuth2HttpClient(restTemplateBuilder: RestTemplateBuilder) : OAuth2HttpClient {
     private val restTemplate: RestTemplate
 
     init {


### PR DESCRIPTION
Vid overgang fra java til kotlin ble DefaultOAuth2HttpClient (per kotlin default) final
Vi ekstender der her, for å få en retry mot tokendings som får timeouts relativt mange ganger https://github.com/navikt/familie-felles/blob/master/http-client/src/main/java/no/nav/familie/http/client/RetryOAuth2HttpClient.kt

Det er mulig man egentlige burde haft en liknende retryclient i token-support, trenger egentlige ikke logging til secureLogs ved feil