### PR TITLE
chore

### DIFF
--- a/token-client-spring/src/main/kotlin/no/nav/security/token/support/client/spring/oauth2/OAuth2ClientRequestInterceptor.kt
+++ b/token-client-spring/src/main/kotlin/no/nav/security/token/support/client/spring/oauth2/OAuth2ClientRequestInterceptor.kt
@@ -24,15 +24,16 @@ import org.springframework.http.client.ClientHttpResponse
 class OAuth2ClientRequestInterceptor(private val properties: ClientConfigurationProperties,
                                      private val service: OAuth2AccessTokenService,
                                      private val matcher: ClientConfigurationPropertiesMatcher) : ClientHttpRequestInterceptor {
-    override fun intercept(req: HttpRequest, body: ByteArray, execution: ClientHttpRequestExecution): ClientHttpResponse {
-        matcher.findProperties(properties, req.uri).orElse(null)
-            ?.also {
-                cfg -> req.headers[AUTHORIZATION]?.let {
-                    req.headers.setBearerAuth(service.getAccessToken(cfg).accessToken)
+    override fun intercept(req: HttpRequest, body: ByteArray, execution: ClientHttpRequestExecution): ClientHttpResponse =
+        with(req) {
+            matcher.findProperties(properties, uri).orElse(null)
+                ?.also {
+                    cfg -> headers[AUTHORIZATION]?.let {
+                    headers.setBearerAuth(service.getAccessToken(cfg).accessToken)
+                    }
                 }
-            }
-        return execution.execute(req, body)
-    }
+             execution.execute(this, body)
+        }
 
     override fun toString() = "$javaClass.simpleName  [properties=$properties, service=$service, matcher=$matcher]"
 

--- a/token-validation-spring/src/main/kotlin/no/nav/security/token/support/spring/validation/interceptor/JwtTokenUnauthorizedException.kt
+++ b/token-validation-spring/src/main/kotlin/no/nav/security/token/support/spring/validation/interceptor/JwtTokenUnauthorizedException.kt
@@ -4,4 +4,4 @@ import org.springframework.http.HttpStatus.UNAUTHORIZED
 import org.springframework.web.bind.annotation.ResponseStatus
 
 @ResponseStatus(UNAUTHORIZED)
-class JwtTokenUnauthorizedException(msg: String? = null, cause: Throwable? = null): RuntimeException(cause)
+class JwtTokenUnauthorizedException(msg: String? = null, cause: Throwable? = null): RuntimeException(msg,cause)

--- a/token-validation-spring/src/main/kotlin/no/nav/security/token/support/spring/validation/interceptor/SpringJwtTokenAnnotationHandler.kt
+++ b/token-validation-spring/src/main/kotlin/no/nav/security/token/support/spring/validation/interceptor/SpringJwtTokenAnnotationHandler.kt
@@ -5,18 +5,12 @@ import no.nav.security.token.support.core.validation.JwtTokenAnnotationHandler
 import org.springframework.core.annotation.AnnotatedElementUtils.findMergedAnnotation
 import java.lang.reflect.AnnotatedElement
 import java.lang.reflect.Method
-import java.util.*
 
 
 class SpringJwtTokenAnnotationHandler(holder: TokenValidationContextHolder?) : JwtTokenAnnotationHandler(holder) {
-    override fun getAnnotation(m: Method, types: List<Class<out Annotation>>): Annotation? = Optional.ofNullable(findAnnotation(m, types))
-        .orElseGet { findAnnotation(m.declaringClass, types) }
+    override fun getAnnotation(m: Method, types: List<Class<out Annotation>>)  =
+        findAnnotation(m, types) ?: findAnnotation(m.declaringClass, types)
 
-    private fun findAnnotation(e: AnnotatedElement, types: List<Class<out Annotation>>): Annotation? {
-        return types.stream()
-            .map { t: Class<out Annotation> -> findMergedAnnotation(e, t) }
-            .filter { Objects.nonNull(it) }
-            .findFirst()
-            .orElse(null)
-    }
+    private fun findAnnotation(e: AnnotatedElement, types: List<Class<out Annotation>>) =
+        types.firstNotNullOfOrNull { t: Class<out Annotation> -> findMergedAnnotation(e, t) }
 }


### PR DESCRIPTION
_SpringJwtTokenAnnotationHandler_ made more kotlin-idiomatic,
_OAuth2ClientRequestInterceptor_ only exchanges token if one is already present, making it more robust for use in unauthenticated health-checks/pings