### PR TITLE
Remove the word exception from INFO logging level - only invalid toke…

### DIFF
--- a/token-validation-core/src/main/java/no/nav/security/token/support/core/validation/JwtTokenValidationHandler.java
+++ b/token-validation-core/src/main/java/no/nav/security/token/support/core/validation/JwtTokenValidationHandler.java
@@ -63,7 +63,7 @@ public class JwtTokenValidationHandler {
 
         } catch (JwtTokenValidatorException e) {
             LOG.info(
-                    "Found invalid token for issuer [{}, expires at {}], exception message:{} ",
+                    "Found invalid token for issuer [{}, expires at {}], message:{} ",
                     jwtToken.getIssuer(),
                     e.getExpiryDate(),
                     e.getMessage());


### PR DESCRIPTION
…n logged.

Q: Lurer også på om `throw new JwtTokenValidatorException("Token validation failed", expiryDate(token), t);` 
egentlig alltid betyr at tokenet har utgått på dato?