### PR TITLE
Mulighet for å oppgi navnet til Auth-header

### DIFF
--- a/token-validation-core/src/main/java/no/nav/security/token/support/core/configuration/IssuerConfiguration.java
+++ b/token-validation-core/src/main/java/no/nav/security/token/support/core/configuration/IssuerConfiguration.java
@@ -5,6 +5,7 @@ import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.as.AuthorizationServerMetadata;
 import no.nav.security.token.support.core.exceptions.MetaDataNotAvailableException;
 import no.nav.security.token.support.core.validation.JwtTokenValidator;
+
 import java.io.IOException;
 import java.net.URL;
 import java.util.List;
@@ -18,6 +19,7 @@ public class IssuerConfiguration {
     private final AuthorizationServerMetadata metadata;
     private final List<String> acceptedAudience;
     private final String cookieName;
+    private final String headerName;
     private final JwtTokenValidator tokenValidator;
     private final ResourceRetriever resourceRetriever;
 
@@ -27,6 +29,7 @@ public class IssuerConfiguration {
         this.metadata = getProviderMetadata(resourceRetriever, issuerProperties.getDiscoveryUrl());
         this.acceptedAudience = issuerProperties.getAcceptedAudience();
         this.cookieName = issuerProperties.getCookieName();
+        this.headerName = issuerProperties.getHeaderName();
         this.tokenValidator = tokenValidator(issuerProperties, metadata, resourceRetriever);
     }
 
@@ -46,6 +49,10 @@ public class IssuerConfiguration {
         return cookieName;
     }
 
+    public String getHeaderName() {
+        return headerName;
+    }
+
     public AuthorizationServerMetadata getMetaData() {
         return metadata;
     }
@@ -58,14 +65,14 @@ public class IssuerConfiguration {
         try {
             return AuthorizationServerMetadata.parse(resourceRetriever.retrieveResource(url).getContent());
         } catch (ParseException | IOException e) {
-            throw new MetaDataNotAvailableException("Make sure you are not using proxying in GCP",url, e);
+            throw new MetaDataNotAvailableException("Make sure you are not using proxying in GCP", url, e);
         }
     }
 
     @Override
     public String toString() {
         return getClass().getSimpleName() + " [name=" + name + ", metaData=" + metadata + ", acceptedAudience="
-            + acceptedAudience + ", cookieName=" + cookieName + ", tokenValidator=" + tokenValidator
+            + acceptedAudience + ", cookieName=" + cookieName + ", headerName=" + headerName + ", tokenValidator=" + tokenValidator
             + ", resourceRetriever=" + resourceRetriever + "]";
     }
 }

--- a/token-validation-core/src/main/java/no/nav/security/token/support/core/configuration/IssuerProperties.java
+++ b/token-validation-core/src/main/java/no/nav/security/token/support/core/configuration/IssuerProperties.java
@@ -8,12 +8,14 @@ import java.util.Objects;
 import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
+import static no.nav.security.token.support.core.JwtTokenConstants.AUTHORIZATION_HEADER;
 
 public class IssuerProperties {
     @NotNull
     private URL discoveryUrl;
     private List<String> acceptedAudience;
     private String cookieName;
+    private String headerName;
     private URL proxyUrl;
     private boolean usePlaintextForHttps = false;
     private Validation validation = new Validation(Collections.emptyList());
@@ -33,6 +35,12 @@ public class IssuerProperties {
         this.cookieName = cookieName;
     }
 
+    public IssuerProperties(URL discoveryUrl, List<String> acceptedAudience, String cookieName, String headerName) {
+        this(discoveryUrl, acceptedAudience);
+        this.cookieName = cookieName;
+        this.headerName = headerName;
+    }
+
     public IssuerProperties(URL discoveryUrl, Validation validation) {
         this(discoveryUrl);
         this.validation = validation;
@@ -48,9 +56,10 @@ public class IssuerProperties {
         this.jwksCache = jwksCache;
     }
 
-    public IssuerProperties(URL discoveryUrl, List<String> acceptedAudience, String cookieName, Validation validation, JwksCache jwksCache) {
+    public IssuerProperties(URL discoveryUrl, List<String> acceptedAudience, String cookieName, String headerName, Validation validation, JwksCache jwksCache) {
         this(discoveryUrl, acceptedAudience);
         this.cookieName = cookieName;
+        this.headerName = headerName;
         this.validation = validation;
         this.jwksCache = jwksCache;
     }
@@ -68,6 +77,14 @@ public class IssuerProperties {
 
     public String getCookieName() {
         return this.cookieName;
+    }
+
+    public String getHeaderName() {
+        if (this.headerName != null && !this.headerName.isEmpty()) {
+            return this.headerName;
+        } else {
+            return AUTHORIZATION_HEADER;
+        }
     }
 
     public URL getProxyUrl() {
@@ -98,6 +115,10 @@ public class IssuerProperties {
         this.cookieName = cookieName;
     }
 
+    public void setHeaderName(String headerName) {
+        this.headerName = headerName;
+    }
+
     public void setProxyUrl(URL proxyUrl) {
         this.proxyUrl = proxyUrl;
     }
@@ -116,7 +137,7 @@ public class IssuerProperties {
 
     @Override
     public String toString() {
-        return "IssuerProperties(discoveryUrl=" + this.getDiscoveryUrl() + ", acceptedAudience=" + this.getAcceptedAudience() + ", cookieName=" + this.getCookieName() + ", proxyUrl=" + this.getProxyUrl() + ", usePlaintextForHttps=" + this.isUsePlaintextForHttps() + ", validation=" + this.getValidation() + ", jwksCache=" + this.getJwksCache() + ")";
+        return "IssuerProperties(discoveryUrl=" + this.getDiscoveryUrl() + ", acceptedAudience=" + this.getAcceptedAudience() + ", cookieName=" + this.getCookieName() + ", headerName=" + this.getHeaderName() + ", proxyUrl=" + this.getProxyUrl() + ", usePlaintextForHttps=" + this.isUsePlaintextForHttps() + ", validation=" + this.getValidation() + ", jwksCache=" + this.getJwksCache() + ")";
     }
 
     public static class Validation {

--- a/token-validation-core/src/test/java/no/nav/security/token/support/core/validation/JwtTokenRetrieverTest.java
+++ b/token-validation-core/src/test/java/no/nav/security/token/support/core/validation/JwtTokenRetrieverTest.java
@@ -45,6 +45,17 @@ class JwtTokenRetrieverTest {
     }
 
     @Test
+    void testRetrieveTokensInHeader2() throws URISyntaxException, MalformedURLException {
+        MultiIssuerConfiguration config = new MultiIssuerConfiguration(
+            createIssuerPropertiesMap("issuer1", "cookie1", "TokenXAuthorization"),
+            new NoopResourceRetriever()
+        );
+        String issuer1Token = createJWT("issuer1");
+        when(request.getHeader("TokenXAuthorization")).thenReturn("Bearer " + issuer1Token);
+        assertEquals("issuer1", JwtTokenRetriever.retrieveUnvalidatedTokens(config, request).get(0).getIssuer());
+    }
+
+    @Test
     void testRetrieveTokensInHeaderIssuerNotConfigured() throws URISyntaxException, MalformedURLException {
         MultiIssuerConfiguration config = new MultiIssuerConfiguration(createIssuerPropertiesMap("issuer1", "cookie1"),
                 new NoopResourceRetriever());
@@ -91,6 +102,21 @@ class JwtTokenRetrieverTest {
         Map<String, IssuerProperties> issuerPropertiesMap = new HashMap<>();
         issuerPropertiesMap.put(issuer,
                 new IssuerProperties(new URI("https://" + issuer).toURL(), Collections.singletonList("aud1"), cookieName));
+        return issuerPropertiesMap;
+    }
+
+    private Map<String, IssuerProperties> createIssuerPropertiesMap(String issuer, String cookieName, String headerName)
+        throws URISyntaxException, MalformedURLException {
+        Map<String, IssuerProperties> issuerPropertiesMap = new HashMap<>();
+        issuerPropertiesMap.put(
+            issuer,
+            new IssuerProperties(
+                new URI("https://" + issuer).toURL(),
+                Collections.singletonList("aud1"),
+                cookieName,
+                headerName
+            )
+        );
         return issuerPropertiesMap;
     }
 

--- a/token-validation-ktor-v2/src/main/kotlin/no/nav/security/token/support/v2/TokenSupportAuthenticationProvider.kt
+++ b/token-validation-ktor-v2/src/main/kotlin/no/nav/security/token/support/v2/TokenSupportAuthenticationProvider.kt
@@ -194,6 +194,7 @@ fun ApplicationConfig.asIssuerProps(): Map<String, IssuerProperties> = this.conf
             URL(issuerConfig.property("discoveryurl").getString()),
             issuerConfig.property("accepted_audience").getString().split(","),
             issuerConfig.propertyOrNull("cookie_name")?.getString(),
+            issuerConfig.propertyOrNull("header_name")?.getString(),
             IssuerProperties.Validation(
                 issuerConfig.propertyOrNull("validation.optional_claims")?.getString()?.split(",") ?: emptyList()
             ),

--- a/token-validation-ktor/src/main/kotlin/no/nav/security/token/support/ktor/TokenSupportAuthenticationProvider.kt
+++ b/token-validation-ktor/src/main/kotlin/no/nav/security/token/support/ktor/TokenSupportAuthenticationProvider.kt
@@ -185,6 +185,7 @@ fun ApplicationConfig.asIssuerProps(): Map<String, IssuerProperties> = this.conf
             URL(issuerConfig.property("discoveryurl").getString()),
             issuerConfig.property("accepted_audience").getString().split(","),
             issuerConfig.propertyOrNull("cookie_name")?.getString(),
+            issuerConfig.propertyOrNull("header_name")?.getString(),
             IssuerProperties.Validation(issuerConfig.propertyOrNull("validation.optional_claims")?.getString()?.split(",") ?: emptyList()),
             IssuerProperties.JwksCache(
                 issuerConfig.propertyOrNull("jwks_cache.lifespan")?.getString()?.toLong(),


### PR DESCRIPTION
meldekort-api fungerer i GCP med ID-porten med sidecar. Det betyr at hvis det ikke finnes en aktiv sesjon i ID-porten, slettes Authorization-header, dvs. appen får ikke token uten registrert sesjon hos ID-porten. Men meldekort-api må jobbe også med DittNAV og andre applikasjoner som bruker TokenX for å få tilgang. Disse appene sender tokene sine gjennom TokenXauthorization-header slik at de ikke trenger aktiv sesjon i ID-porten.
Problemet er at token-support sjekker kun Authorization-header.
Endringene i denne PR'en gjør slik at hver issuer kan ha header_name, på samme måte som coockie_name