### PR TITLE
Oppgraderer til ktor 2.2.1.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <okhttp3.version>4.10.0</okhttp3.version>
         <ktor.version>1.6.8</ktor.version>
         <kotlin.code.style>official</kotlin.code.style>
-        <kotlin.version>1.7.21</kotlin.version>
+        <kotlin.version>1.7.22</kotlin.version>
         <mock-oauth2-server.version>0.5.6</mock-oauth2-server.version>
         <groovy.version>3.0.13</groovy.version>
         <logback.version>1.2.11</logback.version>

--- a/token-client-core/pom.xml
+++ b/token-client-core/pom.xml
@@ -31,11 +31,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <scope>test</scope>

--- a/token-validation-core/pom.xml
+++ b/token-validation-core/pom.xml
@@ -27,11 +27,6 @@
 			<scope>test</scope>
 		</dependency>
         <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>mockwebserver</artifactId>
             <scope>test</scope>

--- a/token-validation-ktor-v2/pom.xml
+++ b/token-validation-ktor-v2/pom.xml
@@ -10,7 +10,7 @@
     <name>token-validation-ktor-v2</name>
 
     <properties>
-        <ktor.version>2.1.3</ktor.version>
+        <ktor.version>2.2.1</ktor.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
- Oppgraderer til kotlin 1.7.22
- Fjerner duplikat dependency assertj-core i token-validation-core og token-client-core. Denne finnes allerede på parent nivå.