### PR TITLE
feat(token-validation-core): consolidate and replace existing validators

### DIFF
--- a/token-validation-core/src/main/java/no/nav/security/token/support/core/configuration/IssuerProperties.java
+++ b/token-validation-core/src/main/java/no/nav/security/token/support/core/configuration/IssuerProperties.java
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory;
 
 import java.net.URL;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 
 import static no.nav.security.token.support.core.JwtTokenConstants.AUTHORIZATION_HEADER;
 
@@ -211,8 +212,16 @@ public class IssuerProperties {
             return this.lifespan;
         }
 
+        public Long getLifespanMillis() {
+            return TimeUnit.MINUTES.toMillis(this.lifespan);
+        }
+
         public Long getRefreshTime() {
             return this.refreshTime;
+        }
+
+        public Long getRefreshTimeMillis() {
+            return TimeUnit.MINUTES.toMillis(this.refreshTime);
         }
 
         public void setLifespan(Long lifespan) {

--- a/token-validation-core/src/main/java/no/nav/security/token/support/core/validation/ConfigurableJwtTokenValidator.java
+++ b/token-validation-core/src/main/java/no/nav/security/token/support/core/validation/ConfigurableJwtTokenValidator.java
@@ -16,6 +16,12 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * Configurable JwtTokenValidator. Allows for optional claims, does not validate audience.
+ *
+ * @deprecated <p>Use {@link DefaultConfigurableJwtValidator} instead.
+ */
+@Deprecated(since = "3.1.3", forRemoval = true)
 public class ConfigurableJwtTokenValidator implements JwtTokenValidator {
 
     private final String issuer;
@@ -54,7 +60,7 @@ public class ConfigurableJwtTokenValidator implements JwtTokenValidator {
 
     private void verify(String tokenString, JWTClaimsSetVerifier<SecurityContext> jwtClaimsSetVerifier, JWSVerificationKeySelector<SecurityContext> keySelector) {
         try {
-            var  jwtProcessor = new DefaultJWTProcessor<>();
+            var jwtProcessor = new DefaultJWTProcessor<>();
             jwtProcessor.setJWSKeySelector(keySelector);
             jwtProcessor.setJWTClaimsSetVerifier(jwtClaimsSetVerifier);
             var token = parse(tokenString);
@@ -76,9 +82,5 @@ public class ConfigurableJwtTokenValidator implements JwtTokenValidator {
         } catch (Throwable t) {
             throw new JwtTokenValidatorException("Token verification failed: " + t.getMessage(), t);
         }
-    }
-
-    protected RemoteJWKSet<SecurityContext> getRemoteJWKSet() {
-        return this.remoteJWKSet;
     }
 }

--- a/token-validation-core/src/main/java/no/nav/security/token/support/core/validation/DefaultConfigurableJwtValidator.java
+++ b/token-validation-core/src/main/java/no/nav/security/token/support/core/validation/DefaultConfigurableJwtValidator.java
@@ -42,7 +42,15 @@ import java.util.stream.Collectors;
  *
  * <p>Specifying optional claims will <i>remove</i> any matching claims from the default set of required claims.</p>
  *
- * <p>An <i>empty</i> list of accepted audiences alone does <i>not</i> remove the audience ("aud") claim from the default set of required claims; the claim must be explicitly specified as optional.</p>
+ * <p>Audience validation is only skipped if the claim is explicitly configured as an optional claim, and the list of accepted audiences is empty / not configured.
+ *
+ * <p>If the audience claim is explicitly configured as an optional claim and the list of accepted audience is non-empty, the following rules apply:
+ * <ul>
+ *     <li>If the audience claim is present (non-empty) in the JWT, it will be matched against the list of accepted audiences.</li>
+ *     <li>If the audience claim is not present, the audience match and existence checks are skipped - since it is an optional claim.</li>
+ * </ul>
+ *
+ * <p>An <i>empty</i> list of accepted audiences alone does <i>not</i> remove the audience ("aud") claim from the default set of required claims; the claim must explicitly be specified as optional.</p>
  */
 public class DefaultConfigurableJwtValidator implements JwtTokenValidator {
     private static final List<String> DEFAULT_REQUIRED_CLAIMS = List.of(

--- a/token-validation-core/src/main/java/no/nav/security/token/support/core/validation/DefaultConfigurableJwtValidator.java
+++ b/token-validation-core/src/main/java/no/nav/security/token/support/core/validation/DefaultConfigurableJwtValidator.java
@@ -1,0 +1,115 @@
+package no.nav.security.token.support.core.validation;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.proc.JWSVerificationKeySelector;
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jwt.JWTClaimNames;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.proc.ConfigurableJWTProcessor;
+import com.nimbusds.jwt.proc.DefaultJWTProcessor;
+import no.nav.security.token.support.core.exceptions.JwtTokenValidatorException;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * The default configurable JwtTokenValidator.
+ * Configures sane defaults and delegates verification to {@link DefaultJwtClaimsVerifier}:
+ *
+ * <p>The following set of claims are required by default and <i>must</i>be present in the JWTs:</p>
+ * <ul>
+ *     <li>iss - Issuer</li>
+ *     <li>sub - Subject</li>
+ *     <li>aud - Audience</li>
+ *     <li>exp - Expiration Time</li>
+ *     <li>iat - Issued At</li>
+ * </ul>
+ *
+ * <p>Otherwise, the following checks are in place:</p>
+ * <ul>
+ *     <li>The issuer ("iss") claim value must match exactly with the specified accepted issuer value.</li>
+ *     <li><i>At least one</i> of the values in audience ("aud") claim must match one of the specified accepted audiences.</li>
+ *     <li>Time validity checks are performed on the issued at ("iat"), expiration ("exp") and not-before ("nbf") claims if and only if they are present.</li>
+ * </ul>
+ *
+ * <p>Note: the not-before ("nbf") claim is <i>not</i> a required claim. Conversely, the expiration ("exp") claim <i>is</i> a default required claim.</p>
+ *
+ * <p>Specifying optional claims will <i>remove</i> any matching claims from the default set of required claims.</p>
+ *
+ * <p>An <i>empty</i> list of accepted audiences alone does <i>not</i> remove the audience ("aud") claim from the default set of required claims; the claim must be explicitly specified as optional.</p>
+ */
+public class DefaultConfigurableJwtValidator implements JwtTokenValidator {
+    private static final List<String> DEFAULT_REQUIRED_CLAIMS = List.of(
+        JWTClaimNames.AUDIENCE,
+        JWTClaimNames.EXPIRATION_TIME,
+        JWTClaimNames.ISSUED_AT,
+        JWTClaimNames.ISSUER,
+        JWTClaimNames.SUBJECT
+    );
+    private static final Set<String> PROHIBITED_CLAIMS = Collections.emptySet();
+    private final JWKSource<SecurityContext> jwkSource;
+    private final ConfigurableJWTProcessor<SecurityContext> jwtProcessor;
+
+    public DefaultConfigurableJwtValidator(String issuer, List<String> acceptedAudiences, JWKSource<SecurityContext> jwkSource) {
+        this(issuer, acceptedAudiences, null, jwkSource);
+    }
+
+    public DefaultConfigurableJwtValidator(String issuer, List<String> acceptedAudiences, List<String> optionalClaims, JWKSource<SecurityContext> jwkSource) {
+        acceptedAudiences = Optional.ofNullable(acceptedAudiences).orElse(List.of());
+        optionalClaims = Optional.ofNullable(optionalClaims).orElse(List.of());
+
+        var requiredClaims = difference(DEFAULT_REQUIRED_CLAIMS, optionalClaims);
+        var exactMatchClaims = new JWTClaimsSet.Builder()
+            .issuer(issuer)
+            .build();
+        var keySelector = new JWSVerificationKeySelector<>(
+            JWSAlgorithm.RS256,
+            jwkSource
+        );
+        var claimsVerifier = new DefaultJwtClaimsVerifier<>(
+            acceptedAudiences(acceptedAudiences, optionalClaims),
+            exactMatchClaims,
+            requiredClaims,
+            PROHIBITED_CLAIMS
+        );
+
+        var jwtProcessor = new DefaultJWTProcessor<>();
+        jwtProcessor.setJWSKeySelector(keySelector);
+        jwtProcessor.setJWTClaimsSetVerifier(claimsVerifier);
+
+        this.jwkSource = jwkSource;
+        this.jwtProcessor = jwtProcessor;
+    }
+
+    @Override
+    public void assertValidToken(String tokenString) throws JwtTokenValidatorException {
+        try {
+            jwtProcessor.process(tokenString, null);
+        } catch (Throwable t) {
+            throw new JwtTokenValidatorException("Token validation failed: " + t.getMessage(), t);
+        }
+    }
+
+    private static Set<String> acceptedAudiences(List<String> acceptedAudiences, List<String> optionalClaims) {
+        if (optionalClaims.contains(JWTClaimNames.AUDIENCE)) {
+            // Make DefaultJWTClaimsVerifier skip the entire audience check (i.e. both match and existence checks)
+            return null;
+        }
+        return new HashSet<>(acceptedAudiences);
+    }
+
+    private static <T> Set<T> difference(List<T> first, List<T> second) {
+        return first.stream()
+            .filter(c -> !second.contains(c))
+            .collect(Collectors.toUnmodifiableSet());
+    }
+
+    protected JWKSource<SecurityContext> getJwkSource() {
+        return this.jwkSource;
+    }
+}

--- a/token-validation-core/src/main/java/no/nav/security/token/support/core/validation/DefaultJwtClaimsVerifier.java
+++ b/token-validation-core/src/main/java/no/nav/security/token/support/core/validation/DefaultJwtClaimsVerifier.java
@@ -1,0 +1,37 @@
+package no.nav.security.token.support.core.validation;
+
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.proc.BadJWTException;
+import com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier;
+import com.nimbusds.jwt.util.DateUtils;
+import com.nimbusds.openid.connect.sdk.validators.BadJWTExceptions;
+
+import java.util.Date;
+import java.util.Set;
+
+/**
+ * Extends {@link com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier} with a time check for the issued at ("iat") claim.
+ * The claim is only checked if it exists in the given claim set.
+ */
+public class DefaultJwtClaimsVerifier<C extends SecurityContext> extends DefaultJWTClaimsVerifier<C> {
+
+    public DefaultJwtClaimsVerifier(final Set<String> acceptedAudience,
+                                    final JWTClaimsSet exactMatchClaims,
+                                    final Set<String> requiredClaims,
+                                    final Set<String> prohibitedClaims) {
+        super(acceptedAudience, exactMatchClaims, requiredClaims, prohibitedClaims);
+    }
+
+    public void verify(final JWTClaimsSet claimsSet, final C context) throws BadJWTException {
+        super.verify(claimsSet, context);
+
+        Date iat = claimsSet.getIssueTime();
+        if (iat != null) {
+            Date now = new Date();
+            if (!iat.equals(now) && !DateUtils.isBefore(iat, now, super.getMaxClockSkew())) {
+                throw BadJWTExceptions.IAT_CLAIM_AHEAD_EXCEPTION;
+            }
+        }
+    }
+}

--- a/token-validation-core/src/main/java/no/nav/security/token/support/core/validation/DefaultJwtTokenValidator.java
+++ b/token-validation-core/src/main/java/no/nav/security/token/support/core/validation/DefaultJwtTokenValidator.java
@@ -20,6 +20,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * "Default" JwtTokenValidator. JWT must have claims that fulfill the OpenID Connect id_token requirements.
+ *
+ * @deprecated <p>Use {@link DefaultConfigurableJwtValidator} instead.
+ */
+@Deprecated(since = "3.1.3", forRemoval = true)
 public class DefaultJwtTokenValidator implements JwtTokenValidator {
     private static final Logger LOG = LoggerFactory.getLogger(DefaultJwtTokenValidator.class);
     private static final JWSAlgorithm JWS_ALG = JWSAlgorithm.RS256;
@@ -93,9 +99,5 @@ public class DefaultJwtTokenValidator implements JwtTokenValidator {
             map.put(aud, createValidator(issuer, aud));
         }
         return map;
-    }
-
-    protected RemoteJWKSet<SecurityContext> getRemoteJWKSet() {
-        return this.remoteJWKSet;
     }
 }

--- a/token-validation-core/src/test/java/no/nav/security/token/support/core/configuration/IssuerConfigurationTest.java
+++ b/token-validation-core/src/test/java/no/nav/security/token/support/core/configuration/IssuerConfigurationTest.java
@@ -4,6 +4,7 @@ import com.nimbusds.oauth2.sdk.as.AuthorizationServerMetadata;
 import no.nav.security.token.support.core.IssuerMockWebServer;
 import no.nav.security.token.support.core.exceptions.MetaDataNotAvailableException;
 import no.nav.security.token.support.core.validation.ConfigurableJwtTokenValidator;
+import no.nav.security.token.support.core.validation.DefaultConfigurableJwtValidator;
 import no.nav.security.token.support.core.validation.DefaultJwtTokenValidator;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -15,6 +16,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class IssuerConfigurationTest {
@@ -38,7 +40,7 @@ class IssuerConfigurationTest {
             "issuer1", new IssuerProperties(issuerMockWebServer.getDiscoveryUrl(), List.of("audience1")), new ProxyAwareResourceRetriever());
         assertThat(config.getMetaData()).isNotNull();
         assertThat(config.getTokenValidator()).isNotNull();
-        assertThat(config.getTokenValidator()).isInstanceOf(DefaultJwtTokenValidator.class);
+        assertThat(config.getTokenValidator()).isInstanceOf(DefaultConfigurableJwtValidator.class);
         AuthorizationServerMetadata metadata = config.getMetaData();
         assertThat(metadata.getIssuer()).isNotNull();
         assertThat(metadata.getJWKSetURI().toString()).isNotNull();
@@ -74,11 +76,11 @@ class IssuerConfigurationTest {
         );
         assertThat(config.getMetaData()).isNotNull();
         assertThat(config.getTokenValidator()).isNotNull();
-        assertThat(config.getTokenValidator()).isInstanceOf(ConfigurableJwtTokenValidator.class);
+        assertThat(config.getTokenValidator()).isInstanceOf(DefaultConfigurableJwtValidator.class);
         AuthorizationServerMetadata metadata = config.getMetaData();
         assertThat(metadata.getIssuer()).isNotNull();
         assertThat(metadata.getJWKSetURI().toString()).isNotNull();
-        assertTrue(!issuerProperties.getJwksCache().isConfigured());
+        assertFalse(issuerProperties.getJwksCache().isConfigured());
         assertTrue(issuerProperties.getValidation().isConfigured());
     }
 
@@ -96,7 +98,7 @@ class IssuerConfigurationTest {
         );
         assertThat(config.getMetaData()).isNotNull();
         assertThat(config.getTokenValidator()).isNotNull();
-        assertThat(config.getTokenValidator()).isInstanceOf(ConfigurableJwtTokenValidator.class);
+        assertThat(config.getTokenValidator()).isInstanceOf(DefaultConfigurableJwtValidator.class);
         AuthorizationServerMetadata metadata = config.getMetaData();
         assertThat(metadata.getIssuer()).isNotNull();
         assertThat(metadata.getJWKSetURI().toString()).isNotNull();

--- a/token-validation-core/src/test/java/no/nav/security/token/support/core/validation/DefaultConfigurableJwtValidatorTest.java
+++ b/token-validation-core/src/test/java/no/nav/security/token/support/core/validation/DefaultConfigurableJwtValidatorTest.java
@@ -44,34 +44,6 @@ public class DefaultConfigurableJwtValidatorTest extends AbstractJwtValidatorTes
     }
 
     @Test
-    void optionalAudienceWithAcceptedAudiencesOnlyDisablesAudienceExistenceCheck() throws JwtTokenValidatorException {
-        var acceptedAudiences = Collections.singletonList("aud1");
-        var optionalClaims = List.of(JWTClaimNames.AUDIENCE);
-        var validator = tokenValidator(acceptedAudiences, optionalClaims);
-
-        validator.assertValidToken(token("aud1"));
-        assertThrows(JwtTokenValidatorException.class, () -> validator.assertValidToken(token("not-aud1")), "should reject invalid audience");
-        validator.assertValidToken(token(Collections.emptyList()));
-        validator.assertValidToken(token(defaultClaims().build()));
-        validator.assertValidToken(token(defaultClaims().audience((String) null).build()));
-        validator.assertValidToken(token(defaultClaims().audience(Collections.emptyList()).build()));
-    }
-
-    @Test
-    void optionalAudienceWithNoAcceptedAudiencesDisablesAudienceValidation() throws JwtTokenValidatorException {
-        var acceptedAudiences = Collections.<String>emptyList();
-        var optionalClaims = List.of(JWTClaimNames.AUDIENCE);
-        var validator = tokenValidator(acceptedAudiences, optionalClaims);
-
-        validator.assertValidToken(token("aud1"));
-        validator.assertValidToken(token("not-aud1"));
-        validator.assertValidToken(token(Collections.emptyList()));
-        validator.assertValidToken(token(defaultClaims().build()));
-        validator.assertValidToken(token(defaultClaims().audience((String) null).build()));
-        validator.assertValidToken(token(defaultClaims().audience(Collections.emptyList()).build()));
-    }
-
-    @Test
     void missingRequiredClaims() throws JwtTokenValidatorException {
         var aud = Collections.singletonList("aud1");
         var validator = tokenValidator(aud);
@@ -144,12 +116,31 @@ public class DefaultConfigurableJwtValidatorTest extends AbstractJwtValidatorTes
     }
 
     @Test
-    void noAcceptedAudiencesWithOptionalClaimShouldAcceptAnyAudience() throws JwtTokenValidatorException {
-        var acceptedAudiences = Collections.<String>emptyList();
-        var optionalClaims = Collections.singletonList(JWTClaimNames.AUDIENCE);
+    void optionalAudienceWithAcceptedAudiencesOnlyDisablesAudienceExistenceCheck() throws JwtTokenValidatorException {
+        var acceptedAudiences = Collections.singletonList("aud1");
+        var optionalClaims = List.of(JWTClaimNames.AUDIENCE);
         var validator = tokenValidator(acceptedAudiences, optionalClaims);
+
         validator.assertValidToken(token("aud1"));
-        validator.assertValidToken(token("aud2"));
+        assertThrows(JwtTokenValidatorException.class, () -> validator.assertValidToken(token("not-aud1")), "should reject invalid audience");
+        validator.assertValidToken(token(Collections.emptyList()));
+        validator.assertValidToken(token(defaultClaims().build()));
+        validator.assertValidToken(token(defaultClaims().audience((String) null).build()));
+        validator.assertValidToken(token(defaultClaims().audience(Collections.emptyList()).build()));
+    }
+
+    @Test
+    void optionalAudienceWithNoAcceptedAudiencesDisablesAudienceValidation() throws JwtTokenValidatorException {
+        var acceptedAudiences = Collections.<String>emptyList();
+        var optionalClaims = List.of(JWTClaimNames.AUDIENCE);
+        var validator = tokenValidator(acceptedAudiences, optionalClaims);
+
+        validator.assertValidToken(token("aud1"));
+        validator.assertValidToken(token("not-aud1"));
+        validator.assertValidToken(token(Collections.emptyList()));
+        validator.assertValidToken(token(defaultClaims().build()));
+        validator.assertValidToken(token(defaultClaims().audience((String) null).build()));
+        validator.assertValidToken(token(defaultClaims().audience(Collections.emptyList()).build()));
     }
 
     @Test

--- a/token-validation-core/src/test/java/no/nav/security/token/support/core/validation/DefaultConfigurableJwtValidatorTest.java
+++ b/token-validation-core/src/test/java/no/nav/security/token/support/core/validation/DefaultConfigurableJwtValidatorTest.java
@@ -32,7 +32,35 @@ public class DefaultConfigurableJwtValidatorTest extends AbstractJwtValidatorTes
     @Test
     void happyPathWithOptionalClaims() throws JwtTokenValidatorException {
         var acceptedAudiences = Collections.singletonList("aud1");
-        var optionalClaims = List.of(JWTClaimNames.SUBJECT, JWTClaimNames.AUDIENCE);
+        var optionalClaims = List.of(JWTClaimNames.SUBJECT);
+        var validator = tokenValidator(acceptedAudiences, optionalClaims);
+
+        validator.assertValidToken(token("aud1"));
+        validator.assertValidToken(token(defaultClaims()
+            .audience("aud1")
+            .subject(null)
+            .build())
+        );
+    }
+
+    @Test
+    void optionalAudienceWithAcceptedAudiencesOnlyDisablesAudienceExistenceCheck() throws JwtTokenValidatorException {
+        var acceptedAudiences = Collections.singletonList("aud1");
+        var optionalClaims = List.of(JWTClaimNames.AUDIENCE);
+        var validator = tokenValidator(acceptedAudiences, optionalClaims);
+
+        validator.assertValidToken(token("aud1"));
+        assertThrows(JwtTokenValidatorException.class, () -> validator.assertValidToken(token("not-aud1")), "should reject invalid audience");
+        validator.assertValidToken(token(Collections.emptyList()));
+        validator.assertValidToken(token(defaultClaims().build()));
+        validator.assertValidToken(token(defaultClaims().audience((String) null).build()));
+        validator.assertValidToken(token(defaultClaims().audience(Collections.emptyList()).build()));
+    }
+
+    @Test
+    void optionalAudienceWithNoAcceptedAudiencesDisablesAudienceValidation() throws JwtTokenValidatorException {
+        var acceptedAudiences = Collections.<String>emptyList();
+        var optionalClaims = List.of(JWTClaimNames.AUDIENCE);
         var validator = tokenValidator(acceptedAudiences, optionalClaims);
 
         validator.assertValidToken(token("aud1"));
@@ -40,8 +68,7 @@ public class DefaultConfigurableJwtValidatorTest extends AbstractJwtValidatorTes
         validator.assertValidToken(token(Collections.emptyList()));
         validator.assertValidToken(token(defaultClaims().build()));
         validator.assertValidToken(token(defaultClaims().audience((String) null).build()));
-        validator.assertValidToken(token(defaultClaims().audience(Collections.emptyList()).subject(null).build()));
-        validator.assertValidToken(token(defaultClaims().subject(null).build()));
+        validator.assertValidToken(token(defaultClaims().audience(Collections.emptyList()).build()));
     }
 
     @Test

--- a/token-validation-core/src/test/java/no/nav/security/token/support/core/validation/DefaultConfigurableJwtValidatorTest.java
+++ b/token-validation-core/src/test/java/no/nav/security/token/support/core/validation/DefaultConfigurableJwtValidatorTest.java
@@ -1,0 +1,202 @@
+package no.nav.security.token.support.core.validation;
+
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.jwk.source.JWKSourceBuilder;
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jwt.JWTClaimNames;
+import no.nav.security.token.support.core.exceptions.JwtTokenValidatorException;
+import org.junit.jupiter.api.Test;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class DefaultConfigurableJwtValidatorTest extends AbstractJwtValidatorTest {
+    private final URL jwksUrl = new URL("https://someurl");
+    private final JWKSource<SecurityContext> jwkSource = JWKSourceBuilder.create(jwksUrl, new MockResourceRetriever()).build();
+
+    DefaultConfigurableJwtValidatorTest() throws MalformedURLException {
+    }
+
+    @Test
+    void happyPath() throws JwtTokenValidatorException {
+        var validator = tokenValidator(Collections.singletonList("aud1"));
+        validator.assertValidToken(token("aud1"));
+    }
+
+    @Test
+    void happyPathWithOptionalClaims() throws JwtTokenValidatorException {
+        var acceptedAudiences = Collections.singletonList("aud1");
+        var optionalClaims = List.of(JWTClaimNames.SUBJECT, JWTClaimNames.AUDIENCE);
+        var validator = tokenValidator(acceptedAudiences, optionalClaims);
+
+        validator.assertValidToken(token("aud1"));
+        validator.assertValidToken(token("not-aud1"));
+        validator.assertValidToken(token(Collections.emptyList()));
+        validator.assertValidToken(token(defaultClaims().build()));
+        validator.assertValidToken(token(defaultClaims().audience((String) null).build()));
+        validator.assertValidToken(token(defaultClaims().audience(Collections.emptyList()).subject(null).build()));
+        validator.assertValidToken(token(defaultClaims().subject(null).build()));
+    }
+
+    @Test
+    void missingRequiredClaims() throws JwtTokenValidatorException {
+        var aud = Collections.singletonList("aud1");
+        var validator = tokenValidator(aud);
+
+        assertThrows(JwtTokenValidatorException.class, () -> {
+            var claims = defaultClaims()
+                .issuer(null)
+                .audience(aud)
+                .build();
+            validator.assertValidToken(token(claims));
+        }, "missing default required issuer claim");
+
+        assertThrows(JwtTokenValidatorException.class, () -> {
+            var claims = defaultClaims()
+                .subject(null)
+                .audience(aud)
+                .build();
+            validator.assertValidToken(token(claims));
+        }, "missing default required subject claim");
+
+        assertThrows(JwtTokenValidatorException.class, () -> {
+            var claims = defaultClaims()
+                .audience(Collections.emptyList())
+                .build();
+            validator.assertValidToken(token(claims));
+        }, "missing default required audience claim");
+
+        assertThrows(JwtTokenValidatorException.class, () -> {
+            var claims = defaultClaims()
+                .audience(aud)
+                .expirationTime(null)
+                .build();
+            validator.assertValidToken(token(claims));
+        }, "missing default required expiration time claim");
+
+        assertThrows(JwtTokenValidatorException.class, () -> {
+            var claims = defaultClaims()
+                .audience(aud)
+                .issueTime(null)
+                .build();
+            validator.assertValidToken(token(claims));
+        }, "missing default required issued at claim");
+    }
+
+    @Test
+    void atLeastOneAudienceMustMatch() throws JwtTokenValidatorException {
+        var validator = tokenValidator(Collections.singletonList("aud1"));
+        validator.assertValidToken(token("aud1"));
+        validator.assertValidToken(token(List.of("aud1", "aud2")));
+        assertThrows(JwtTokenValidatorException.class, () -> validator.assertValidToken(token(List.of("aud2", "aud3"))), "at least one audience must match accepted audiences");
+    }
+
+    @Test
+    void multipleAcceptedAudiences() throws JwtTokenValidatorException {
+        var acceptedAudiences = List.of("aud1", "aud2");
+        var validator = tokenValidator(acceptedAudiences);
+        validator.assertValidToken(token("aud1"));
+        validator.assertValidToken(token("aud2"));
+        validator.assertValidToken(token(List.of("aud1", "aud2")));
+        assertThrows(JwtTokenValidatorException.class, () -> validator.assertValidToken(token("aud3")), "unknown audience should be rejected");
+    }
+
+    @Test
+    void noAcceptedAudiences() throws JwtTokenValidatorException {
+        var acceptedAudiences = Collections.<String>emptyList();
+        var validator = tokenValidator(acceptedAudiences);
+        assertThrows(JwtTokenValidatorException.class, () -> validator.assertValidToken(token("aud1")), "unknown audience should be rejected");
+        assertThrows(JwtTokenValidatorException.class, () -> validator.assertValidToken(token(Collections.emptyList())), "missing required audience claim");
+        assertThrows(JwtTokenValidatorException.class, () -> validator.assertValidToken(token((String) null)), "missing required audience claim");
+    }
+
+    @Test
+    void noAcceptedAudiencesWithOptionalClaimShouldAcceptAnyAudience() throws JwtTokenValidatorException {
+        var acceptedAudiences = Collections.<String>emptyList();
+        var optionalClaims = Collections.singletonList(JWTClaimNames.AUDIENCE);
+        var validator = tokenValidator(acceptedAudiences, optionalClaims);
+        validator.assertValidToken(token("aud1"));
+        validator.assertValidToken(token("aud2"));
+    }
+
+    @Test
+    void issuerMismatch() throws JwtTokenValidatorException {
+        var aud = Collections.singletonList("aud1");
+        var validator = tokenValidator(aud);
+        assertThrows(JwtTokenValidatorException.class, () -> {
+            var token = token(defaultClaims()
+                .audience(aud)
+                .issuer("invalid-issuer")
+                .build());
+            validator.assertValidToken(token);
+        });
+    }
+
+    @Test
+    void missingNbfShouldNotFail() throws JwtTokenValidatorException {
+        var acceptedAudiences = Collections.singletonList("aud1");
+        var validator = tokenValidator(acceptedAudiences);
+        var token = token(defaultClaims()
+            .audience(acceptedAudiences)
+            .notBeforeTime(null)
+            .build());
+        validator.assertValidToken(token);
+    }
+
+    @Test
+    void expBeforeNowShouldFail() throws JwtTokenValidatorException {
+        var acceptedAudiences = Collections.singletonList("aud1");
+        var validator = tokenValidator(acceptedAudiences);
+        var now = new Date();
+        var beforeNow = new Date(now.getTime() - maxClockSkewMillis());
+        var token = token(defaultClaims()
+            .audience(acceptedAudiences)
+            .expirationTime(beforeNow)
+            .build());
+        assertThrows(JwtTokenValidatorException.class, () -> validator.assertValidToken(token));
+    }
+
+    @Test
+    void iatAfterNowShouldFail() throws JwtTokenValidatorException {
+        var acceptedAudiences = Collections.singletonList("aud1");
+        var validator = tokenValidator(acceptedAudiences);
+        var now = new Date();
+        var afterNow = new Date(now.getTime() + maxClockSkewMillis());
+        var token = token(defaultClaims()
+            .audience(acceptedAudiences)
+            .issueTime(afterNow)
+            .build());
+        assertThrows(JwtTokenValidatorException.class, () -> validator.assertValidToken(token));
+    }
+
+    @Test
+    void nbfAfterNowShouldFail() throws JwtTokenValidatorException {
+        var acceptedAudiences = Collections.singletonList("aud1");
+        var validator = tokenValidator(acceptedAudiences);
+        var now = new Date();
+        var afterNow = new Date(now.getTime() + maxClockSkewMillis());
+        var token = token(defaultClaims()
+            .audience(acceptedAudiences)
+            .notBeforeTime(afterNow)
+            .build());
+        assertThrows(JwtTokenValidatorException.class, () -> validator.assertValidToken(token));
+    }
+
+    private JwtTokenValidator tokenValidator(List<String> acceptedAudiences) {
+        return new DefaultConfigurableJwtValidator(DEFAULT_ISSUER, acceptedAudiences, jwkSource);
+    }
+
+    private JwtTokenValidator tokenValidator(List<String> acceptedAudiences, List<String> optionalClaims) {
+        return new DefaultConfigurableJwtValidator(DEFAULT_ISSUER, acceptedAudiences, optionalClaims, jwkSource);
+    }
+
+    private long maxClockSkewMillis() {
+        return TimeUnit.SECONDS.toMillis(DefaultJwtClaimsVerifier.DEFAULT_MAX_CLOCK_SKEW_SECONDS + 5);
+    }
+}

--- a/token-validation-core/src/test/java/no/nav/security/token/support/core/validation/JwtTokenValidatorFactoryTest.java
+++ b/token-validation-core/src/test/java/no/nav/security/token/support/core/validation/JwtTokenValidatorFactoryTest.java
@@ -1,9 +1,10 @@
 package no.nav.security.token.support.core.validation;
 
 
-import com.nimbusds.jose.jwk.source.DefaultJWKSetCache;
-import com.nimbusds.jose.jwk.source.JWKSetCache;
-import com.nimbusds.jose.jwk.source.RemoteJWKSet;
+import com.nimbusds.jose.jwk.source.JWKSetBasedJWKSource;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.jwk.source.JWKSourceBuilder;
+import com.nimbusds.jose.jwk.source.RefreshAheadCachingJWKSetSource;
 import com.nimbusds.jose.proc.SecurityContext;
 import com.nimbusds.jose.util.ResourceRetriever;
 import com.nimbusds.oauth2.sdk.as.AuthorizationServerMetadata;
@@ -19,11 +20,12 @@ import org.mockito.quality.Strictness;
 
 import java.net.MalformedURLException;
 import java.net.URI;
+import java.net.URL;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static com.nimbusds.jose.jwk.source.DefaultJWKSetCache.DEFAULT_LIFESPAN_MINUTES;
-import static com.nimbusds.jose.jwk.source.DefaultJWKSetCache.DEFAULT_REFRESH_TIME_MINUTES;
+import static com.nimbusds.jose.jwk.source.JWKSourceBuilder.DEFAULT_CACHE_REFRESH_TIMEOUT;
+import static com.nimbusds.jose.jwk.source.JWKSourceBuilder.DEFAULT_CACHE_TIME_TO_LIVE;
 import static no.nav.security.token.support.core.validation.JwtTokenValidatorFactory.tokenValidator;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -33,18 +35,20 @@ import static org.mockito.Mockito.when;
 class JwtTokenValidatorFactoryTest {
 
     @Mock
-    private RemoteJWKSet<SecurityContext> remoteJWKSet;
-    @Mock
     private AuthorizationServerMetadata metadata;
     @Mock
     private ResourceRetriever resourceRetriever;
 
     private IssuerProperties issuerProperties;
+    private final URL url = new URL("http://url");
+
+    JwtTokenValidatorFactoryTest() throws MalformedURLException {
+    }
 
     @BeforeEach
-    void setup() throws MalformedURLException {
+    void setup() {
         issuerProperties = new IssuerProperties(
-            URI.create("http://url").toURL(),
+            url,
             List.of("aud1")
         );
         when(metadata.getJWKSetURI()).thenReturn(URI.create("http://someurl"));
@@ -52,50 +56,65 @@ class JwtTokenValidatorFactoryTest {
     }
 
     @Test
-    void testCreateDefaultJwtTokenValidator() {
-        assertThat(tokenValidator(issuerProperties, metadata, resourceRetriever))
-            .isInstanceOf(DefaultJwtTokenValidator.class);
+    void createDefaultTokenValidator() {
+        var defaultValidator = tokenValidator(issuerProperties, metadata, resourceRetriever);
+        assertThat(defaultValidator).isInstanceOf(DefaultConfigurableJwtValidator.class);
+
+        var source = getJwkSource(defaultValidator);
+        assertThat(source).isInstanceOf(JWKSetBasedJWKSource.class);
+
+        var basedSource = ((JWKSetBasedJWKSource<?>) source);
+        assertThat(basedSource.getJWKSetSource()).isInstanceOf(RefreshAheadCachingJWKSetSource.class);
+
+        var cache = ((RefreshAheadCachingJWKSetSource<?>) basedSource.getJWKSetSource());
+        assertThat(cache.getTimeToLive()).isEqualTo(DEFAULT_CACHE_TIME_TO_LIVE);
+        assertThat(cache.getCacheRefreshTimeout()).isEqualTo(DEFAULT_CACHE_REFRESH_TIMEOUT);
     }
 
     @Test
-    void testCreateConfigurableJwtTokenValidator() {
-        issuerProperties.setValidation(new IssuerProperties.Validation(List.of("optionalclaim")));
+    void createTokenValidatorWithOptionalClaim() {
+        issuerProperties = new IssuerProperties(
+            url,
+            new IssuerProperties.Validation(List.of("optionalclaim")),
+            IssuerProperties.JwksCache.EMPTY
+        );
         var validatorWithDefaultCache = tokenValidator(issuerProperties, metadata, resourceRetriever);
-        assertThat(validatorWithDefaultCache).isInstanceOf(ConfigurableJwtTokenValidator.class);
+        assertThat(validatorWithDefaultCache).isInstanceOf(DefaultConfigurableJwtValidator.class);
     }
 
     @Test
-    void testCreateJwtTokenValidatorWithDefaultCacheValues() {
-        var validatorWithDefaultCache = tokenValidator(issuerProperties, metadata, resourceRetriever);
-        assertThat(validatorWithDefaultCache).isInstanceOf(DefaultJwtTokenValidator.class);
-        var cache = getCache(validatorWithDefaultCache);
-        assertThat(cache).isInstanceOf(DefaultJWKSetCache.class);
-        assertThat(((DefaultJWKSetCache) cache).getLifespan(TimeUnit.MINUTES)).isEqualTo(DEFAULT_LIFESPAN_MINUTES);
-        assertThat(((DefaultJWKSetCache) cache).getRefreshTime(TimeUnit.MINUTES)).isEqualTo(DEFAULT_REFRESH_TIME_MINUTES);
-    }
+    void createTokenValidatorWithCustomJwksCache() {
+        var jwksCacheProperties = new IssuerProperties.JwksCache(5L, 1L);
+        issuerProperties = new IssuerProperties(
+            url,
+            new IssuerProperties.Validation(List.of("optionalclaim")),
+            jwksCacheProperties
+        );
 
-    @Test
-    void testCreateJwtTokenValidatorWithCustomCacheValues() {
-        issuerProperties.setJwksCache(new IssuerProperties.JwksCache(1L, 2L));
         var validatorWithCustomCache = tokenValidator(issuerProperties, metadata, resourceRetriever);
-        assertThat(validatorWithCustomCache).isInstanceOf(DefaultJwtTokenValidator.class);
-        var cache = getCache(validatorWithCustomCache);
-        assertThat(cache).isInstanceOf(DefaultJWKSetCache.class);
-        assertThat(((DefaultJWKSetCache) cache).getLifespan(TimeUnit.MINUTES)).isEqualTo(1L);
-        assertThat(((DefaultJWKSetCache) cache).getRefreshTime(TimeUnit.MINUTES)).isEqualTo(2L);
+        assertThat(validatorWithCustomCache).isInstanceOf(DefaultConfigurableJwtValidator.class);
+
+        var source = getJwkSource(validatorWithCustomCache);
+        assertThat(source).isInstanceOf(JWKSetBasedJWKSource.class);
+
+        var basedSource = ((JWKSetBasedJWKSource<?>) source);
+        assertThat(basedSource.getJWKSetSource()).isInstanceOf(RefreshAheadCachingJWKSetSource.class);
+
+        var cache = ((RefreshAheadCachingJWKSetSource<?>) basedSource.getJWKSetSource());
+        assertThat(cache.getTimeToLive()).isEqualTo(jwksCacheProperties.getLifespanMillis());
+        assertThat(cache.getCacheRefreshTimeout()).isEqualTo(jwksCacheProperties.getRefreshTimeMillis());
     }
 
     @Test
-    void testCreateValidatorWithProvidedRemoteJWKSet() {
-        var jwtTokenValidator = tokenValidator(issuerProperties, metadata, remoteJWKSet);
-        var cache = new DefaultJWKSetCache(1L, 2L, TimeUnit.MINUTES);
-        when(remoteJWKSet.getJWKSetCache()).thenReturn(cache);
-        assertThat(getCache(jwtTokenValidator)).isEqualTo(cache);
+    void createTokenValidatorWithProvidedJwkSource() {
+        var jwkSource = JWKSourceBuilder.create(url)
+            .cache(TimeUnit.MINUTES.toMillis(5), TimeUnit.MINUTES.toMillis(1))
+            .build();
+        var jwtTokenValidator = tokenValidator(issuerProperties, metadata, jwkSource);
+        assertThat(getJwkSource(jwtTokenValidator)).isEqualTo(jwkSource);
     }
 
-    private static JWKSetCache getCache(JwtTokenValidator jwtTokenValidator) {
-        return jwtTokenValidator instanceof ConfigurableJwtTokenValidator ?
-            ((ConfigurableJwtTokenValidator) jwtTokenValidator).getRemoteJWKSet().getJWKSetCache() :
-            ((DefaultJwtTokenValidator) jwtTokenValidator).getRemoteJWKSet().getJWKSetCache();
+    private static JWKSource<SecurityContext> getJwkSource(JwtTokenValidator jwtTokenValidator) {
+        return ((DefaultConfigurableJwtValidator) jwtTokenValidator).getJwkSource();
     }
 }

--- a/token-validation-ktor-v2/src/main/kotlin/no/nav/security/token/support/v2/TokenSupportAuthenticationProvider.kt
+++ b/token-validation-ktor-v2/src/main/kotlin/no/nav/security/token/support/v2/TokenSupportAuthenticationProvider.kt
@@ -192,7 +192,7 @@ fun ApplicationConfig.asIssuerProps(): Map<String, IssuerProperties> = this.conf
     .associate { issuerConfig ->
         issuerConfig.property("issuer_name").getString() to IssuerProperties(
             URL(issuerConfig.property("discoveryurl").getString()),
-            issuerConfig.property("accepted_audience").getString().split(","),
+            issuerConfig.propertyOrNull("accepted_audience")?.getString()?.split(","),
             issuerConfig.propertyOrNull("cookie_name")?.getString(),
             issuerConfig.propertyOrNull("header_name")?.getString(),
             IssuerProperties.Validation(

--- a/token-validation-ktor/src/main/kotlin/no/nav/security/token/support/ktor/TokenSupportAuthenticationProvider.kt
+++ b/token-validation-ktor/src/main/kotlin/no/nav/security/token/support/ktor/TokenSupportAuthenticationProvider.kt
@@ -183,7 +183,7 @@ fun ApplicationConfig.asIssuerProps(): Map<String, IssuerProperties> = this.conf
     .associate { issuerConfig ->
         issuerConfig.property("issuer_name").getString() to IssuerProperties(
             URL(issuerConfig.property("discoveryurl").getString()),
-            issuerConfig.property("accepted_audience").getString().split(","),
+            issuerConfig.propertyOrNull("accepted_audience")?.getString()?.split(","),
             issuerConfig.propertyOrNull("cookie_name")?.getString(),
             issuerConfig.propertyOrNull("header_name")?.getString(),
             IssuerProperties.Validation(issuerConfig.propertyOrNull("validation.optional_claims")?.getString()?.split(",") ?: emptyList()),


### PR DESCRIPTION
## Problem

`token-validation-core` currently exists of two implementations that satisfy the `JwtTokenValidator` interface:
- `DefaultJwtTokenValidator`
- `ConfigurableJwtTokenValidator`

These are instantiated through `JwtTokenValidatorFactory`, with the latter validator being chosen if an application has configured the `no.nav.security.jwt.issuer.[issuer shortname].validation.optional-claims` property.

There are multiple issues with both of these validators.

For `ConfigurableJwtTokenValidator`:

- The `accepted-audience` property is not passed in to the validator.
  - Effectively, this means that the audience (`aud`) claim is never validated, regardless of it being defined as an
  optional claim or not.
- The not-before (`nbf`) claim is set as required by default. Many providers in the wild do not include this claim (e.g. ID-porten).
  - We should still validate the claim if present, but we shouldn't require the existence of the claim.
- The issued at claim (`iat`) is not validated at all, beyond checking for its existence in the JWT.

For `DefaultJwtTokenValidator`:

- Uses the Nimbus `IDTokenValidator` as a backing validator.
- This effectively requires all JWTs to conform to an `id_token` as per the OpenID Connect specifications, which means that claims such as audience (`aud`) is now always required.
- The validator only allows the client to accept a single audience, which is its `client_id`. This is in accordance with the OIDC spec, but we don't really pass `id_tokens` to resource servers (anymore) - which is what this library is primarily meant for.
  - This restriction means that we need to maintain a separate backing validator for each accepted audience. 
  - In most cases we want to accept a token if there is _at least one_ matching accepted audience (in the case of multiple values in the audience claim).
- The validator will also look for and require the existence of the `azp` claim in the case of a JWT containing more than one audience, which again is a behaviour only defined in the OIDC specifications for validating `id_tokens`.

To sum up, there are gotchas with both of these validators that aren't immediately apparent for an end-user, depending on their configuration.

## Solution

We introduce the `DefaultConfigurableJwtValidator` implementation that combines the best of both validators to address the above problems. Effectively, it uses the same backing validator as `ConfigurableJwtTokenValidator` but has the following improvements:

- Time validity checks for the issued at claim (`iat`).
- The audience (`aud`) claim is still a required claim by default, and is validated against the configured list of accepted audiences.
  - The validation is only skipped if the claim is explicitly configured as an optional claim, and the list of accepted audiences is empty / not configured. 
  - If the claim is explicitly configured as an optional claim and the list of accepted audience is non-empty:
    - If the audience claim is present (non-empty) in the JWT, it will be matched against the list of accepted audiences.
    - If the audience claim is not present, the audience match and existence checks are skipped - since it is an optional claim.
- The not-before (`nbf`) claim is no longer set as required by default, but will always be validated if present in the JWT.
- Loosens the strict audience validation found in `IDTokenValidator` to be more in line with "normal" JWT validation.

This new validator replaces the previous two validators (`DefaultJwtTokenValidator` and `ConfigurableJwtTokenValidator`) in the `JwtTokenValidatorFactory`. 

The previous validators are now marked as deprecated. There shouldn't be any breaking API changes as far as I can tell; I've attempted to keep compatibility and just deprecate existing methods - most of this is likely only used internally by the other modules anyway. A minor version bump would suffice I think?

## Other

- Replaced the usage of `RemoteJWKSet` and `DefaultJWKSetCache` from Nimbus, both of which are deprecated.
- Made the `accepted_audience` configuration property optional for `token-validation-ktor` and `token-validation-ktor-v2` to align with the equivalent configuration for the other modules.