### PR TITLE
Maven-complier-plugin setter parameter flagget til true

### DIFF
--- a/token-validation-spring/pom.xml
+++ b/token-validation-spring/pom.xml
@@ -195,6 +195,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <parameters>true</parameters>
+                </configuration>
                 <executions>
                     <execution>
                         <id>compile</id>


### PR DESCRIPTION
Vi har flere warnings I loggen av typen:

> Using deprecated '-debug' fallback for parameter name resolution. Compile the affected code with '-parameters' instead or avoid its introspection: no.nav.security.token.support.client.core.ClientProperties$TokenExchangeProperties

Ref. https://stackoverflow.com/a/74601911 and https://stackoverflow.com/a/75629035