### PR TITLE
fix(build): use matching kotlin version for compiler plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,7 @@
                 <plugin>
                     <groupId>org.jetbrains.kotlin</groupId>
                     <artifactId>kotlin-maven-plugin</artifactId>
+                    <version>${kotlin.version}</version>
                     <executions>
                         <execution>
                             <id>compile</id>


### PR DESCRIPTION
Current master fails as the plugin resolves to version [2.0.0-Beta1](https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-maven-plugin/2.0.0-Beta1).