### PR TITLE
deprecate OAuth2GrantType

### DIFF
--- a/token-client-core/src/main/kotlin/no/nav/security/token/support/client/core/ClientProperties.kt
+++ b/token-client-core/src/main/kotlin/no/nav/security/token/support/client/core/ClientProperties.kt
@@ -1,16 +1,14 @@
 package no.nav.security.token.support.client.core;
 
 import com.nimbusds.jose.util.DefaultResourceRetriever;
+import com.nimbusds.oauth2.sdk.GrantType
 import com.nimbusds.oauth2.sdk.ParseException
 import com.nimbusds.oauth2.sdk.`as`.AuthorizationServerMetadata
 import java.io.IOException
-import no.nav.security.token.support.client.core.OAuth2GrantType.Companion.CLIENT_CREDENTIALS
-import no.nav.security.token.support.client.core.OAuth2GrantType.Companion.JWT_BEARER
-import no.nav.security.token.support.client.core.OAuth2GrantType.Companion.TOKEN_EXCHANGE
 import java.net.URI
 class ClientProperties @JvmOverloads constructor(var tokenEndpointUrl: URI? = null,
                                                  private val wellKnownUrl: URI? = null,
-                                                 val grantType: OAuth2GrantType,
+                                                 val grantType: GrantType,
                                                  val scope: List<String> = emptyList(),
                                                  val authentication: ClientAuthenticationProperties,
                                                  val resourceUrl: URI? = null,
@@ -32,15 +30,15 @@ class ClientProperties @JvmOverloads constructor(var tokenEndpointUrl: URI? = nu
             .tokenExchange(tokenExchange)
 
     companion object {
-        private val GRANT_TYPES = listOf(JWT_BEARER, CLIENT_CREDENTIALS, TOKEN_EXCHANGE)
+        private val GRANT_TYPES = listOf(GrantType.JWT_BEARER, GrantType.CLIENT_CREDENTIALS, GrantType.TOKEN_EXCHANGE)
 
        @JvmStatic
-        fun builder(grantType: OAuth2GrantType, authentication: ClientAuthenticationProperties) = ClientPropertiesBuilder(grantType, authentication)
+        fun builder(grantType: GrantType, authentication: ClientAuthenticationProperties) = ClientPropertiesBuilder(grantType, authentication)
 
         private fun endpointUrlFromMetadata(wellKnown: URI?) =
             runCatching {
                 wellKnown?.let { AuthorizationServerMetadata.parse(DefaultResourceRetriever().retrieveResource(wellKnown.toURL()).content).tokenEndpointURI }
-                    ?: throw OAuth2ClientException("Well known url cannot be null, please check your configuration")
+                    ?: throw OAuth2ClientException("Well knowcn url cannot be null, please check your configuration")
             }.getOrElse {
                 when(it) {
                     is ParseException-> throw OAuth2ClientException("Unable to parse response from $wellKnown", it)
@@ -51,7 +49,7 @@ class ClientProperties @JvmOverloads constructor(var tokenEndpointUrl: URI? = nu
             }
     }
 
-    class ClientPropertiesBuilder @JvmOverloads constructor(private val grantType: OAuth2GrantType, val authentication: ClientAuthenticationProperties,
+    class ClientPropertiesBuilder @JvmOverloads constructor(private val grantType: GrantType, val authentication: ClientAuthenticationProperties,
                                                             private var tokenEndpointUrl: URI? = null,
                                                             private var wellKnownUrl: URI? = null,
                                                             private var scope: List<String> = emptyList(),

--- a/token-client-core/src/main/kotlin/no/nav/security/token/support/client/core/OAuth2CacheFactory.kt
+++ b/token-client-core/src/main/kotlin/no/nav/security/token/support/client/core/OAuth2CacheFactory.kt
@@ -18,7 +18,7 @@ object OAuth2CacheFactory {
     private fun <T> evictOnResponseExpiresIn(skewInSeconds : Long) : Expiry<T, OAuth2AccessTokenResponse> {
         return object : Expiry<T, OAuth2AccessTokenResponse> {
             override fun expireAfterCreate(key : T, response : OAuth2AccessTokenResponse, currentTime : Long) =
-                SECONDS.toNanos(if (response.expiresIn!! > skewInSeconds) response.expiresIn - skewInSeconds else response.expiresIn.toLong())
+                SECONDS.toNanos(if (response.expiresIn!! > skewInSeconds) response.expiresIn!! - skewInSeconds else response.expiresIn!!.toLong())
             override fun expireAfterUpdate(key : T, response : OAuth2AccessTokenResponse, currentTime : Long, currentDuration : Long) = currentDuration
             override fun expireAfterRead(key : T, response : OAuth2AccessTokenResponse, currentTime : Long, currentDuration : Long) = currentDuration
         }

--- a/token-client-core/src/main/kotlin/no/nav/security/token/support/client/core/OAuth2GrantType.kt
+++ b/token-client-core/src/main/kotlin/no/nav/security/token/support/client/core/OAuth2GrantType.kt
@@ -1,14 +1,20 @@
 package no.nav.security.token.support.client.core
 
- data class OAuth2GrantType(@JvmField val value : String) {
+import com.nimbusds.oauth2.sdk.GrantType
+
+@Deprecated("Use GrantType from nimbus instead", ReplaceWith("GrantType"), DeprecationLevel.WARNING)
+data class OAuth2GrantType(@JvmField val value : String) {
      fun value() = value
 
     companion object {
        @JvmField
-        val JWT_BEARER = OAuth2GrantType("urn:ietf:params:oauth:grant-type:jwt-bearer")
+       @Deprecated("Use GrantType.JWT_BEARER from nimbus instead")
+       val JWT_BEARER = OAuth2GrantType(GrantType.JWT_BEARER.value)
         @JvmField
-        val CLIENT_CREDENTIALS = OAuth2GrantType("client_credentials")
+        @Deprecated("Use GrantType.CLIENT_CREDENTIALS from nimbus instead")
+        val CLIENT_CREDENTIALS = OAuth2GrantType(GrantType.CLIENT_CREDENTIALS.value)
         @JvmField
-        val TOKEN_EXCHANGE = OAuth2GrantType("urn:ietf:params:oauth:grant-type:token-exchange")
+        @Deprecated("Use GrantType.TOKEN_EXCHANGE from nimbus instead")
+        val TOKEN_EXCHANGE = OAuth2GrantType(GrantType.TOKEN_EXCHANGE.value)
     }
 }

--- a/token-client-core/src/main/kotlin/no/nav/security/token/support/client/core/auth/ClientAssertion.kt
+++ b/token-client-core/src/main/kotlin/no/nav/security/token/support/client/core/auth/ClientAssertion.kt
@@ -1,6 +1,5 @@
 package no.nav.security.token.support.client.core.auth
 
-import com.nimbusds.jose.JOSEException
 import com.nimbusds.jose.JOSEObjectType.*
 import com.nimbusds.jose.JWSAlgorithm.*
 import com.nimbusds.jose.JWSHeader
@@ -9,8 +8,8 @@ import com.nimbusds.jose.jwk.RSAKey
 import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.JWTClaimsSet.Builder
 import com.nimbusds.jwt.SignedJWT
+import com.nimbusds.oauth2.sdk.auth.JWTAuthentication.*
 import java.net.URI
-import java.time.Instant
 import java.time.Instant.*
 import java.util.Date
 import java.util.UUID
@@ -32,7 +31,7 @@ class ClientAssertion(private val tokenEndpointUrl : URI, private val clientId :
                 .build()).serialize()
         }
 
-    fun assertionType() = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+    fun assertionType() = CLIENT_ASSERTION_TYPE
 
     private fun createSignedJWT(rsaJwk : RSAKey, claimsSet : JWTClaimsSet) =
 

--- a/token-client-core/src/main/kotlin/no/nav/security/token/support/client/core/http/OAuth2HttpHeaders.kt
+++ b/token-client-core/src/main/kotlin/no/nav/security/token/support/client/core/http/OAuth2HttpHeaders.kt
@@ -19,11 +19,7 @@ class OAuth2HttpHeaders (val headers : Map<String, List<String>>) {
 
     class Builder(private val headers : TreeMap<String, MutableList<String>> =  TreeMap(CASE_INSENSITIVE_ORDER)) {
 
-        fun header(name : String, value : String) =
-            this.also {
-                headers.computeIfAbsent(name) { ArrayList(1) }
-                    .add(value)
-            }
+        fun header(name : String, value : String) = this.also { headers.computeIfAbsent(name) { ArrayList(1) }.add(value) }
 
         fun build() = of(headers)
     }

--- a/token-client-core/src/main/kotlin/no/nav/security/token/support/client/core/jwk/JwkFactory.kt
+++ b/token-client-core/src/main/kotlin/no/nav/security/token/support/client/core/jwk/JwkFactory.kt
@@ -1,16 +1,17 @@
 package no.nav.security.token.support.client.core.jwk
 
 import com.nimbusds.jose.jwk.JWKSet
+import com.nimbusds.jose.jwk.JWKSet.*
 import com.nimbusds.jose.jwk.RSAKey
 import com.nimbusds.jose.jwk.RSAKey.Builder
-import com.nimbusds.jose.util.Base64URL.*
+import com.nimbusds.jose.jwk.RSAKey.parse
+import com.nimbusds.jose.util.Base64URL.encode
 import java.io.InputStream
-import java.nio.charset.StandardCharsets.*
-import java.nio.file.Files
-import java.nio.file.Path
+import java.nio.charset.StandardCharsets.UTF_8
+import java.nio.file.Files.readString
+import java.nio.file.Path.of
 import java.security.KeyStore
-import java.security.MessageDigest.*
-import java.security.NoSuchAlgorithmException
+import java.security.MessageDigest.getInstance
 import org.slf4j.LoggerFactory
 
 object JwkFactory {
@@ -19,17 +20,17 @@ object JwkFactory {
     @JvmStatic
     fun fromJsonFile(filePath : String) =
         runCatching {
-            LOG.debug("Attempting to read jwk from path: {}", Path.of(filePath).toAbsolutePath())
-            fromJson(Files.readString(Path.of(filePath), UTF_8))
+            LOG.debug("Attempting to read JWK from path: {}", of(filePath).toAbsolutePath())
+            fromJson(readString(of(filePath), UTF_8))
         }.getOrElse {
             throw JwkInvalidException(it)
         }
 
 
     @JvmStatic
-    fun fromJson(jsonJwk : String) =
+    fun fromJson(jwk : String) =
         runCatching {
-            RSAKey.parse(jsonJwk)
+            parse(jwk)
         }.getOrElse {
             throw JwkInvalidException(it)
         }
@@ -48,7 +49,7 @@ object JwkFactory {
             KeyStore.getInstance("JKS").run {
                 with(password.toCharArray()) {
                     load(keyStoreFile, this)
-                    JWKSet.load(this@run) { this }
+                    load(this@run) { this }
                 }
             }
         }.getOrElse {

--- a/token-client-core/src/main/kotlin/no/nav/security/token/support/client/core/oauth2/AbstractOAuth2GrantRequest.kt
+++ b/token-client-core/src/main/kotlin/no/nav/security/token/support/client/core/oauth2/AbstractOAuth2GrantRequest.kt
@@ -1,10 +1,10 @@
 package no.nav.security.token.support.client.core.oauth2
 
+import com.nimbusds.oauth2.sdk.GrantType
 import java.util.Objects
 import no.nav.security.token.support.client.core.ClientProperties
-import no.nav.security.token.support.client.core.OAuth2GrantType
 
-abstract class AbstractOAuth2GrantRequest(val grantType : OAuth2GrantType, val clientProperties : ClientProperties) {
+abstract class AbstractOAuth2GrantRequest(val grantType : GrantType, val clientProperties : ClientProperties) {
 
     override fun equals(other : Any?) : Boolean {
         if (this === other) return true

--- a/token-client-core/src/main/kotlin/no/nav/security/token/support/client/core/oauth2/AbstractOAuth2TokenClient.kt
+++ b/token-client-core/src/main/kotlin/no/nav/security/token/support/client/core/oauth2/AbstractOAuth2TokenClient.kt
@@ -1,6 +1,6 @@
 package no.nav.security.token.support.client.core.oauth2
 
-import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod
+import com.nimbusds.oauth2.sdk.GrantType
 import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod.*
 import java.lang.String.*
 import java.nio.charset.StandardCharsets
@@ -8,7 +8,6 @@ import java.util.Base64
 import java.util.Optional
 import no.nav.security.token.support.client.core.ClientProperties
 import no.nav.security.token.support.client.core.OAuth2ClientException
-import no.nav.security.token.support.client.core.OAuth2GrantType
 import no.nav.security.token.support.client.core.OAuth2ParameterNames
 import no.nav.security.token.support.client.core.auth.ClientAssertion
 import no.nav.security.token.support.client.core.http.OAuth2HttpClient
@@ -51,8 +50,8 @@ abstract class AbstractOAuth2TokenClient<T : AbstractOAuth2GrantRequest?> intern
     fun createDefaultFormParameters(grantRequest : T) : MutableMap<String, String> {
         val clientProperties = grantRequest?.clientProperties ?: throw OAuth2ClientException("ClientProperties cannot be null")
         val formParameters : MutableMap<String, String> = LinkedHashMap(clientAuthenticationFormParameters(grantRequest))
-        formParameters[OAuth2ParameterNames.GRANT_TYPE] = grantRequest.grantType.value()
-        if (clientProperties.grantType != OAuth2GrantType.TOKEN_EXCHANGE) {
+        formParameters[OAuth2ParameterNames.GRANT_TYPE] = grantRequest.grantType.value
+        if (clientProperties.grantType != GrantType.TOKEN_EXCHANGE) {
             formParameters[OAuth2ParameterNames.SCOPE] = join(" ", clientProperties.scope)
         }
         return formParameters

--- a/token-client-core/src/main/kotlin/no/nav/security/token/support/client/core/oauth2/ClientCredentialsGrantRequest.kt
+++ b/token-client-core/src/main/kotlin/no/nav/security/token/support/client/core/oauth2/ClientCredentialsGrantRequest.kt
@@ -1,6 +1,6 @@
 package no.nav.security.token.support.client.core.oauth2
 
+import com.nimbusds.oauth2.sdk.GrantType
 import no.nav.security.token.support.client.core.ClientProperties
-import no.nav.security.token.support.client.core.OAuth2GrantType.Companion.CLIENT_CREDENTIALS
 
-class ClientCredentialsGrantRequest(clientProperties : ClientProperties) : AbstractOAuth2GrantRequest(CLIENT_CREDENTIALS, clientProperties)
+class ClientCredentialsGrantRequest(clientProperties : ClientProperties) : AbstractOAuth2GrantRequest(GrantType.CLIENT_CREDENTIALS, clientProperties)

--- a/token-client-core/src/main/kotlin/no/nav/security/token/support/client/core/oauth2/OAuth2AccessTokenResponse.kt
+++ b/token-client-core/src/main/kotlin/no/nav/security/token/support/client/core/oauth2/OAuth2AccessTokenResponse.kt
@@ -1,7 +1,7 @@
 package no.nav.security.token.support.client.core.oauth2
 
  data class OAuth2AccessTokenResponse (var access_token : String? = null,  var expires_at : Int? = null,  var expires_in : Int? = 60, private val additionalParameters : Map<String, Any> = emptyMap()) {
-     val accessToken = access_token
-     val expiresAt = expires_at
-     val expiresIn = expires_in
+     val accessToken get()  = access_token
+     val expiresAt get() = expires_at
+     val expiresIn get()  = expires_in
 }

--- a/token-client-core/src/main/kotlin/no/nav/security/token/support/client/core/oauth2/OAuth2AccessTokenService.kt
+++ b/token-client-core/src/main/kotlin/no/nav/security/token/support/client/core/oauth2/OAuth2AccessTokenService.kt
@@ -1,13 +1,13 @@
 package no.nav.security.token.support.client.core.oauth2
 
 import com.github.benmanes.caffeine.cache.Cache
+import com.nimbusds.oauth2.sdk.GrantType.CLIENT_CREDENTIALS
+import com.nimbusds.oauth2.sdk.GrantType.JWT_BEARER
+import com.nimbusds.oauth2.sdk.GrantType.TOKEN_EXCHANGE
 import java.util.function.Function
 import org.slf4j.LoggerFactory
 import no.nav.security.token.support.client.core.ClientProperties
 import no.nav.security.token.support.client.core.OAuth2ClientException
-import no.nav.security.token.support.client.core.OAuth2GrantType.Companion.CLIENT_CREDENTIALS
-import no.nav.security.token.support.client.core.OAuth2GrantType.Companion.JWT_BEARER
-import no.nav.security.token.support.client.core.OAuth2GrantType.Companion.TOKEN_EXCHANGE
 import no.nav.security.token.support.client.core.context.JwtBearerTokenResolver
 
 class OAuth2AccessTokenService @JvmOverloads constructor(private val tokenResolver : JwtBearerTokenResolver,
@@ -21,12 +21,12 @@ class OAuth2AccessTokenService @JvmOverloads constructor(private val tokenResolv
 
 
     fun getAccessToken(clientProperties : ClientProperties) : OAuth2AccessTokenResponse? {
-        log.debug("Getting access_token for grant={}", clientProperties.grantType)
+        log.trace("Getting access_token for grant={}", clientProperties.grantType)
         return when (clientProperties.grantType) {
             JWT_BEARER -> executeOnBehalfOf(clientProperties)
             CLIENT_CREDENTIALS -> executeClientCredentials(clientProperties)
             TOKEN_EXCHANGE -> executeTokenExchange(clientProperties)
-            else -> throw OAuth2ClientException("invalid grant-type=${clientProperties.grantType.value()} from OAuth2ClientConfig.OAuth2Client. grant-type not in supported grant-types ($SUPPORTED_GRANT_TYPES)")
+            else -> throw OAuth2ClientException("invalid grant-type=${clientProperties.grantType.value} from OAuth2ClientConfig.OAuth2Client. grant-type not in supported grant-types ($SUPPORTED_GRANT_TYPES)")
         }
     }
 

--- a/token-client-core/src/main/kotlin/no/nav/security/token/support/client/core/oauth2/OnBehalfOfGrantRequest.kt
+++ b/token-client-core/src/main/kotlin/no/nav/security/token/support/client/core/oauth2/OnBehalfOfGrantRequest.kt
@@ -1,11 +1,10 @@
 package no.nav.security.token.support.client.core.oauth2
 
+import com.nimbusds.oauth2.sdk.GrantType
 import java.util.Objects
 import no.nav.security.token.support.client.core.ClientProperties
-import no.nav.security.token.support.client.core.OAuth2GrantType
-import no.nav.security.token.support.client.core.OAuth2GrantType.Companion.JWT_BEARER
 
-class OnBehalfOfGrantRequest(clientProperties : ClientProperties, val assertion : String) : AbstractOAuth2GrantRequest(JWT_BEARER, clientProperties) {
+class OnBehalfOfGrantRequest(clientProperties : ClientProperties, val assertion : String) : AbstractOAuth2GrantRequest(GrantType.JWT_BEARER, clientProperties) {
 
     override fun equals(other : Any?) : Boolean {
         if (this === other) return true

--- a/token-client-core/src/main/kotlin/no/nav/security/token/support/client/core/oauth2/TokenExchangeGrantRequest.kt
+++ b/token-client-core/src/main/kotlin/no/nav/security/token/support/client/core/oauth2/TokenExchangeGrantRequest.kt
@@ -1,10 +1,10 @@
 package no.nav.security.token.support.client.core.oauth2
 
+import com.nimbusds.oauth2.sdk.GrantType
 import java.util.Objects
 import no.nav.security.token.support.client.core.ClientProperties
-import no.nav.security.token.support.client.core.OAuth2GrantType.Companion.TOKEN_EXCHANGE
 
-class TokenExchangeGrantRequest(clientProperties : ClientProperties, val subjectToken : String) : AbstractOAuth2GrantRequest(TOKEN_EXCHANGE,
+class TokenExchangeGrantRequest(clientProperties : ClientProperties, val subjectToken : String) : AbstractOAuth2GrantRequest(GrantType.TOKEN_EXCHANGE,
     clientProperties) {
 
     override fun equals(other : Any?) : Boolean {

--- a/token-client-core/src/test/kotlin/no/nav/security/token/support/client/core/ClientPropertiesTest.kt
+++ b/token-client-core/src/test/kotlin/no/nav/security/token/support/client/core/ClientPropertiesTest.kt
@@ -1,5 +1,6 @@
 package no.nav.security.token.support.client.core
 
+import com.nimbusds.oauth2.sdk.GrantType
 import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod
 import java.io.IOException
 import java.net.URI
@@ -28,15 +29,9 @@ internal class ClientPropertiesTest {
 
     @Test
     fun validGrantTypes() {
-        Assertions.assertNotNull(clientPropertiesFromGrantType(OAuth2GrantType.JWT_BEARER))
-        Assertions.assertNotNull(clientPropertiesFromGrantType(OAuth2GrantType.CLIENT_CREDENTIALS))
-        Assertions.assertNotNull(clientPropertiesFromGrantType(OAuth2GrantType.TOKEN_EXCHANGE))
-    }
-
-    @Test
-    fun invalidGrantTypes() {
-        org.assertj.core.api.Assertions.assertThatExceptionOfType(IllegalArgumentException::class.java)
-            .isThrownBy { clientPropertiesFromGrantType(OAuth2GrantType("somegrantNotSupported")) }
+        Assertions.assertNotNull(clientPropertiesFromGrantType(GrantType.JWT_BEARER))
+        Assertions.assertNotNull(clientPropertiesFromGrantType(GrantType.CLIENT_CREDENTIALS))
+        Assertions.assertNotNull(clientPropertiesFromGrantType(GrantType.TOKEN_EXCHANGE))
     }
 
     @Test
@@ -63,7 +58,7 @@ internal class ClientPropertiesTest {
             return ClientProperties(
                 null,
                 wellKnownUrl,
-                OAuth2GrantType.CLIENT_CREDENTIALS, listOf("scope1", "scope2"),
+                GrantType.CLIENT_CREDENTIALS, listOf("scope1", "scope2"),
                 clientAuth(),
                 null,
                 tokenExchange()
@@ -85,7 +80,7 @@ internal class ClientPropertiesTest {
                                           )
         }
 
-        private fun clientPropertiesFromGrantType(grantType : OAuth2GrantType) : ClientProperties {
+        private fun clientPropertiesFromGrantType(grantType : GrantType) : ClientProperties {
             return ClientProperties(
                 URI.create("http://token"),
                 null,

--- a/token-client-core/src/test/kotlin/no/nav/security/token/support/client/core/TestUtils.kt
+++ b/token-client-core/src/test/kotlin/no/nav/security/token/support/client/core/TestUtils.kt
@@ -3,6 +3,7 @@ package no.nav.security.token.support.client.core
 import com.nimbusds.jwt.JWT
 import com.nimbusds.jwt.JWTClaimsSet.Builder
 import com.nimbusds.jwt.PlainJWT
+import com.nimbusds.oauth2.sdk.GrantType
 import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod
 import java.io.IOException
 import java.io.UnsupportedEncodingException
@@ -29,7 +30,7 @@ object TestUtils {
     const val CONTENT_TYPE_FORM_URL_ENCODED = "application/x-www-form-urlencoded;charset=UTF-8"
     const val CONTENT_TYPE_JSON = "application/json;charset=UTF-8"
     @JvmStatic
-    fun clientProperties(tokenEndpointUrl : String?, oAuth2GrantType : OAuth2GrantType?) : ClientProperties {
+    fun clientProperties(tokenEndpointUrl : String?, oAuth2GrantType : GrantType?) : ClientProperties {
         return builder(oAuth2GrantType!!, builder("client1", ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
             .clientSecret("clientSecret1")
             .build())
@@ -40,7 +41,7 @@ object TestUtils {
 
     fun tokenExchangeClientProperties(
         tokenEndpointUrl : String?,
-        oAuth2GrantType : OAuth2GrantType?,
+        oAuth2GrantType : GrantType?,
         clientPrivateKey : String?
                                      ) : ClientProperties {
         return builder(oAuth2GrantType!!, builder("client1", ClientAuthenticationMethod.PRIVATE_KEY_JWT)

--- a/token-client-core/src/test/kotlin/no/nav/security/token/support/client/core/auth/ClientAssertionTest.kt
+++ b/token-client-core/src/test/kotlin/no/nav/security/token/support/client/core/auth/ClientAssertionTest.kt
@@ -6,6 +6,7 @@ import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.JWSVerifier
 import com.nimbusds.jose.crypto.RSASSAVerifier
 import com.nimbusds.jwt.SignedJWT
+import com.nimbusds.oauth2.sdk.GrantType
 import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod
 import java.net.URI
 import java.text.ParseException
@@ -13,10 +14,10 @@ import java.time.Instant
 import java.util.Date
 import java.util.Objects
 import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.*
 import org.junit.jupiter.api.Test
 import no.nav.security.token.support.client.core.ClientAuthenticationProperties.Companion.builder
 import no.nav.security.token.support.client.core.ClientProperties.Companion.builder
-import no.nav.security.token.support.client.core.OAuth2GrantType
 
 internal class ClientAssertionTest {
 
@@ -26,29 +27,29 @@ internal class ClientAssertionTest {
         val clientAuth = builder("client1", ClientAuthenticationMethod.PRIVATE_KEY_JWT)
             .clientJwk("src/test/resources/jwk.json")
             .build()
-        val clientProperties = builder(OAuth2GrantType.CLIENT_CREDENTIALS, clientAuth)
+        val clientProperties = builder(GrantType.CLIENT_CREDENTIALS, clientAuth)
             .tokenEndpointUrl(URI.create("http://token"))
             .build()
         val now = Instant.now()
         val clientAssertion = ClientAssertion(
             clientProperties.tokenEndpointUrl!!,
             clientProperties.authentication)
-        Assertions.assertThat(clientAssertion).isNotNull()
-        Assertions.assertThat(clientAssertion.assertionType()).isEqualTo("urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
+        assertThat(clientAssertion).isNotNull()
+        assertThat(clientAssertion.assertionType()).isEqualTo("urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
         val assertion = clientAssertion.assertion()
-        Assertions.assertThat(clientAssertion.assertion()).isNotNull()
+        assertThat(clientAssertion.assertion()).isNotNull()
         val signedJWT = SignedJWT.parse(assertion)
         val keyId = Objects.requireNonNull(clientProperties.authentication.clientRsaKey)?.keyID
-        Assertions.assertThat(signedJWT.header.keyID).isEqualTo(keyId)
-        Assertions.assertThat(signedJWT.header.type).isEqualTo(JOSEObjectType.JWT)
-        Assertions.assertThat(signedJWT.header.algorithm).isEqualTo(JWSAlgorithm.RS256)
+        assertThat(signedJWT.header.keyID).isEqualTo(keyId)
+        assertThat(signedJWT.header.type).isEqualTo(JOSEObjectType.JWT)
+        assertThat(signedJWT.header.algorithm).isEqualTo(JWSAlgorithm.RS256)
         val verifier : JWSVerifier = RSASSAVerifier(Objects.requireNonNull(clientAuth.clientRsaKey))
-        Assertions.assertThat(signedJWT.verify(verifier)).isTrue()
+        assertThat(signedJWT.verify(verifier)).isTrue()
         val claims = signedJWT.jwtClaimsSet
-        Assertions.assertThat(claims.subject).isEqualTo(clientAuth.clientId)
-        Assertions.assertThat(claims.issuer).isEqualTo(clientAuth.clientId)
-        Assertions.assertThat(claims.audience).containsExactly(clientProperties.tokenEndpointUrl.toString())
-        Assertions.assertThat(claims.expirationTime).isAfter(Date.from(now))
-        Assertions.assertThat(claims.notBeforeTime).isBefore(claims.expirationTime)
+        assertThat(claims.subject).isEqualTo(clientAuth.clientId)
+        assertThat(claims.issuer).isEqualTo(clientAuth.clientId)
+        assertThat(claims.audience).containsExactly(clientProperties.tokenEndpointUrl.toString())
+        assertThat(claims.expirationTime).isAfter(Date.from(now))
+        assertThat(claims.notBeforeTime).isBefore(claims.expirationTime)
     }
 }

--- a/token-client-core/src/test/kotlin/no/nav/security/token/support/client/core/oauth2/ClientCredentialsTokenClientTest.kt
+++ b/token-client-core/src/test/kotlin/no/nav/security/token/support/client/core/oauth2/ClientCredentialsTokenClientTest.kt
@@ -1,5 +1,6 @@
 package no.nav.security.token.support.client.core.oauth2
 
+import com.nimbusds.oauth2.sdk.GrantType
 import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod
 import java.io.IOException
 import java.net.URI
@@ -13,7 +14,6 @@ import no.nav.security.token.support.client.core.ClientAuthenticationProperties.
 import no.nav.security.token.support.client.core.ClientProperties
 import no.nav.security.token.support.client.core.ClientProperties.Companion.builder
 import no.nav.security.token.support.client.core.OAuth2ClientException
-import no.nav.security.token.support.client.core.OAuth2GrantType
 import no.nav.security.token.support.client.core.TestUtils.assertPostMethodAndJsonHeaders
 import no.nav.security.token.support.client.core.TestUtils.clientProperties
 import no.nav.security.token.support.client.core.TestUtils.decodeBasicAuth
@@ -44,7 +44,7 @@ internal class ClientCredentialsTokenClientTest {
     @Test
     fun tokenResponseWithDefaultClientAuthMethod()  {
             server!!.enqueue(jsonResponse(TOKEN_RESPONSE))
-            val clientProperties = clientProperties(tokenEndpointUrl, OAuth2GrantType.CLIENT_CREDENTIALS)
+            val clientProperties = clientProperties(tokenEndpointUrl, GrantType.CLIENT_CREDENTIALS)
             val response = client!!.getTokenResponse(ClientCredentialsGrantRequest(clientProperties))
             val recordedRequest = server!!.takeRequest()
             assertPostMethodAndJsonHeaders(recordedRequest)
@@ -57,7 +57,7 @@ internal class ClientCredentialsTokenClientTest {
     @Test
     fun  tokenResponseWithClientSecretBasic() {
             server!!.enqueue(jsonResponse(TOKEN_RESPONSE))
-            val clientProperties = clientProperties(tokenEndpointUrl, OAuth2GrantType.CLIENT_CREDENTIALS)
+            val clientProperties = clientProperties(tokenEndpointUrl, GrantType.CLIENT_CREDENTIALS)
             val response = client!!.getTokenResponse(ClientCredentialsGrantRequest(clientProperties))
             val recordedRequest = server!!.takeRequest()
             assertPostMethodAndJsonHeaders(recordedRequest)
@@ -76,7 +76,7 @@ internal class ClientCredentialsTokenClientTest {
                 .clientSecret("secret")
                 .build())
             .build();*/
-            val clientProperties = builder(OAuth2GrantType.CLIENT_CREDENTIALS, builder("client", ClientAuthenticationMethod.CLIENT_SECRET_POST)
+            val clientProperties = builder(GrantType.CLIENT_CREDENTIALS, builder("client", ClientAuthenticationMethod.CLIENT_SECRET_POST)
                 .clientSecret("secret").build())
                 .tokenEndpointUrl(URI.create(tokenEndpointUrl))
                 .scope(listOf("scope1", "scope2"))
@@ -101,7 +101,7 @@ internal class ClientCredentialsTokenClientTest {
                 .build())
             .build();
 */
-            val clientProperties = builder(OAuth2GrantType.CLIENT_CREDENTIALS, builder("client", ClientAuthenticationMethod.PRIVATE_KEY_JWT)
+            val clientProperties = builder(GrantType.CLIENT_CREDENTIALS, builder("client", ClientAuthenticationMethod.PRIVATE_KEY_JWT)
                 .clientSecret("secret")
                 .clientJwk("src/test/resources/jwk.json")
                 .build())
@@ -124,7 +124,7 @@ internal class ClientCredentialsTokenClientTest {
                 .isThrownBy {
                     client!!.getTokenResponse(ClientCredentialsGrantRequest(clientProperties(
                         tokenEndpointUrl,
-                        OAuth2GrantType.CLIENT_CREDENTIALS
+                        GrantType.CLIENT_CREDENTIALS
                                                                                             )))
                 }
         }

--- a/token-client-core/src/test/kotlin/no/nav/security/token/support/client/core/oauth2/OAuth2AccessTokenServiceTest.kt
+++ b/token-client-core/src/test/kotlin/no/nav/security/token/support/client/core/oauth2/OAuth2AccessTokenServiceTest.kt
@@ -2,6 +2,7 @@ package no.nav.security.token.support.client.core.oauth2
 
 import com.nimbusds.jwt.JWTClaimsSet.Builder
 import com.nimbusds.jwt.PlainJWT
+import com.nimbusds.oauth2.sdk.GrantType
 import java.time.Instant
 import java.time.LocalDateTime.*
 import java.time.ZoneId.*
@@ -23,9 +24,6 @@ import org.mockito.MockitoAnnotations
 import no.nav.security.token.support.client.core.ClientProperties.TokenExchangeProperties
 import no.nav.security.token.support.client.core.OAuth2CacheFactory.accessTokenResponseCache
 import no.nav.security.token.support.client.core.OAuth2ClientException
-import no.nav.security.token.support.client.core.OAuth2GrantType
-import no.nav.security.token.support.client.core.OAuth2GrantType.Companion.CLIENT_CREDENTIALS
-import no.nav.security.token.support.client.core.OAuth2GrantType.Companion.TOKEN_EXCHANGE
 import no.nav.security.token.support.client.core.TestUtils.clientProperties
 import no.nav.security.token.support.client.core.context.JwtBearerTokenResolver
 
@@ -208,18 +206,18 @@ internal class OAuth2AccessTokenServiceTest {
         private fun clientCredentialsProperties() = clientCredentialsProperties("scope1", "scope2")
 
         private fun clientCredentialsProperties(vararg scope : String) =
-            clientProperties("http://token", CLIENT_CREDENTIALS)
+            clientProperties("http://token", GrantType.CLIENT_CREDENTIALS)
                 .toBuilder()
                 .scope(Arrays.asList(*scope))
                 .build()
 
         private fun exchangeProperties(audience : String = "audience") =
-            clientProperties("http://token", TOKEN_EXCHANGE)
+            clientProperties("http://token", GrantType.TOKEN_EXCHANGE)
                 .toBuilder()
                 .tokenExchange(TokenExchangeProperties(audience))
                 .build()
 
-        private fun onBehalfOfProperties() = clientProperties("http://token", OAuth2GrantType.JWT_BEARER)
+        private fun onBehalfOfProperties() = clientProperties("http://token", GrantType.JWT_BEARER)
 
         private fun accessTokenResponse(assertion : String, expiresIn : Int) =
             OAuth2AccessTokenResponse(assertion, Math.toIntExact(Instant.now().plusSeconds(expiresIn.toLong()).epochSecond), expiresIn)

--- a/token-client-core/src/test/kotlin/no/nav/security/token/support/client/core/oauth2/OnBehalfOfTokenClientTest.kt
+++ b/token-client-core/src/test/kotlin/no/nav/security/token/support/client/core/oauth2/OnBehalfOfTokenClientTest.kt
@@ -1,5 +1,6 @@
 package no.nav.security.token.support.client.core.oauth2
 
+import com.nimbusds.oauth2.sdk.GrantType
 import java.io.IOException
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
@@ -10,7 +11,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.MockitoAnnotations
 import no.nav.security.token.support.client.core.OAuth2ClientException
-import no.nav.security.token.support.client.core.OAuth2GrantType
 import no.nav.security.token.support.client.core.TestUtils.assertPostMethodAndJsonHeaders
 import no.nav.security.token.support.client.core.TestUtils.clientProperties
 import no.nav.security.token.support.client.core.TestUtils.jsonResponse
@@ -42,13 +42,13 @@ internal class OnBehalfOfTokenClientTest {
     fun tokenResponse()  {
             server!!.enqueue(jsonResponse(TOKEN_RESPONSE))
             val assertion = jwt("sub1").serialize()
-            val clientProperties = clientProperties(tokenEndpointUrl, OAuth2GrantType.JWT_BEARER)
+            val clientProperties = clientProperties(tokenEndpointUrl, GrantType.JWT_BEARER)
             val oAuth2OnBehalfOfGrantRequest = OnBehalfOfGrantRequest(clientProperties, assertion)
             val response = onBehalfOfTokenResponseClient!!.getTokenResponse(oAuth2OnBehalfOfGrantRequest)
             val recordedRequest = server!!.takeRequest()
             assertPostMethodAndJsonHeaders(recordedRequest)
             val formParameters = recordedRequest.body.readUtf8()
-            Assertions.assertThat(formParameters).contains("grant_type=" + URLEncoder.encode(OAuth2GrantType.JWT_BEARER.value(),
+            Assertions.assertThat(formParameters).contains("grant_type=" + URLEncoder.encode(GrantType.JWT_BEARER.value,
                 StandardCharsets.UTF_8))
                 .contains("scope=scope1+scope2")
                 .contains("requested_token_use=on_behalf_of")
@@ -63,7 +63,7 @@ internal class OnBehalfOfTokenClientTest {
     fun  tokenResponseWithError() {
             server!!.enqueue(jsonResponse(ERROR_RESPONSE).setResponseCode(400))
             val assertion = jwt("sub1").serialize()
-            val clientProperties = clientProperties(tokenEndpointUrl, OAuth2GrantType.JWT_BEARER)
+            val clientProperties = clientProperties(tokenEndpointUrl, GrantType.JWT_BEARER)
             val oAuth2OnBehalfOfGrantRequest = OnBehalfOfGrantRequest(clientProperties, assertion)
             Assertions.assertThatExceptionOfType(OAuth2ClientException::class.java)
                 .isThrownBy { onBehalfOfTokenResponseClient!!.getTokenResponse(oAuth2OnBehalfOfGrantRequest) }

--- a/token-client-core/src/test/kotlin/no/nav/security/token/support/client/core/oauth2/TokenExchangeClientTest.kt
+++ b/token-client-core/src/test/kotlin/no/nav/security/token/support/client/core/oauth2/TokenExchangeClientTest.kt
@@ -1,5 +1,6 @@
 package no.nav.security.token.support.client.core.oauth2
 
+import com.nimbusds.oauth2.sdk.GrantType
 import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod
 import java.io.IOException
 import java.net.URI
@@ -13,7 +14,6 @@ import no.nav.security.token.support.client.core.ClientProperties
 import no.nav.security.token.support.client.core.ClientProperties.Companion.builder
 import no.nav.security.token.support.client.core.ClientProperties.TokenExchangeProperties
 import no.nav.security.token.support.client.core.OAuth2ClientException
-import no.nav.security.token.support.client.core.OAuth2GrantType
 import no.nav.security.token.support.client.core.OAuth2ParameterNames
 import no.nav.security.token.support.client.core.TestUtils.assertPostMethodAndJsonHeaders
 import no.nav.security.token.support.client.core.TestUtils.clientProperties
@@ -58,7 +58,7 @@ internal class TokenExchangeClientTest {
                 .build())
             .build();
 */
-            val clientProperties = builder(OAuth2GrantType.TOKEN_EXCHANGE, builder("client1", ClientAuthenticationMethod.PRIVATE_KEY_JWT)
+            val clientProperties = builder(GrantType.TOKEN_EXCHANGE, builder("client1", ClientAuthenticationMethod.PRIVATE_KEY_JWT)
                 .clientJwk("src/test/resources/jwk.json")
                 .build())
                 .tokenEndpointUrl(URI.create(tokenEndpointUrl))
@@ -79,13 +79,13 @@ internal class TokenExchangeClientTest {
                 .isThrownBy {
                     tokenExchangeClient!!.getTokenResponse(TokenExchangeGrantRequest(clientProperties(
                         tokenEndpointUrl,
-                        OAuth2GrantType.TOKEN_EXCHANGE
+                        GrantType.TOKEN_EXCHANGE
                                                                                                      ), subjectToken!!))
                 }
         }
 
     private fun assertThatRequestBodyContainsTokenExchangeFormParameters(formParameters : String) {
-        Assertions.assertThat(formParameters).contains(OAuth2ParameterNames.GRANT_TYPE + "=" + encodeValue(OAuth2GrantType.TOKEN_EXCHANGE.value()))
+        Assertions.assertThat(formParameters).contains(OAuth2ParameterNames.GRANT_TYPE + "=" + encodeValue(GrantType.TOKEN_EXCHANGE.value))
         Assertions.assertThat(formParameters).contains(OAuth2ParameterNames.AUDIENCE + "=" + "audience")
         Assertions.assertThat(formParameters).contains(OAuth2ParameterNames.SUBJECT_TOKEN_TYPE + "=" + encodeValue("urn:ietf:params:oauth:token-type:jwt"))
         Assertions.assertThat(formParameters).contains(OAuth2ParameterNames.SUBJECT_TOKEN + "=" + subjectToken)

--- a/token-client-kotlin-demo/src/main/kotlin/no/nav/security/token/support/ktor/Application.kt
+++ b/token-client-kotlin-demo/src/main/kotlin/no/nav/security/token/support/ktor/Application.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.nimbusds.jwt.SignedJWT
+import com.nimbusds.oauth2.sdk.GrantType
 import io.ktor.application.Application
 import io.ktor.application.call
 import io.ktor.application.install
@@ -24,7 +25,6 @@ import io.ktor.response.respond
 import io.ktor.routing.get
 import io.ktor.routing.routing
 import no.nav.security.mock.oauth2.MockOAuth2Server
-import no.nav.security.token.support.client.core.OAuth2GrantType
 import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenResponse
 import no.nav.security.token.support.ktor.oauth.ClientConfig
 
@@ -67,7 +67,7 @@ fun Application.module() {
             call.respond(
                 HttpStatusCode.OK,
                 DemoTokenResponse(
-                    OAuth2GrantType.CLIENT_CREDENTIALS.value,
+                    GrantType.CLIENT_CREDENTIALS.value,
                     oAuth2Response
                 )
             )
@@ -79,7 +79,7 @@ fun Application.module() {
                 call.respond(
                     HttpStatusCode.OK,
                     DemoTokenResponse(
-                        OAuth2GrantType.JWT_BEARER.value,
+                        GrantType.JWT_BEARER.value,
                         oAuth2Response
                     )
                 )
@@ -90,7 +90,7 @@ fun Application.module() {
                 call.respond(
                     HttpStatusCode.OK,
                     DemoTokenResponse(
-                        OAuth2GrantType.TOKEN_EXCHANGE.value,
+                        GrantType.TOKEN_EXCHANGE.value,
                         oAuth2Response
                     )
                 )

--- a/token-client-kotlin-demo/src/main/kotlin/no/nav/security/token/support/ktor/oauth/OAuth2Client.kt
+++ b/token-client-kotlin-demo/src/main/kotlin/no/nav/security/token/support/ktor/oauth/OAuth2Client.kt
@@ -2,6 +2,7 @@ package no.nav.security.token.support.ktor.oauth
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.github.benmanes.caffeine.cache.AsyncLoadingCache
+import com.nimbusds.oauth2.sdk.GrantType
 import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod
 import io.ktor.client.HttpClient
 import io.ktor.client.request.forms.submitForm
@@ -15,7 +16,6 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.runBlocking
 import no.nav.security.token.support.client.core.ClientAuthenticationProperties
-import no.nav.security.token.support.client.core.OAuth2GrantType
 import no.nav.security.token.support.client.core.OAuth2ParameterNames
 import no.nav.security.token.support.client.core.auth.ClientAssertion
 import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenResponse
@@ -69,13 +69,13 @@ class OAuth2Client(
 }
 
 data class GrantRequest(
-    val grantType: OAuth2GrantType,
+    val grantType: GrantType,
     val params: Map<String, String> = emptyMap()
 ) {
     companion object {
         fun tokenExchange(token: String, audience: String): GrantRequest =
             GrantRequest(
-                grantType = OAuth2GrantType.TOKEN_EXCHANGE,
+                grantType = GrantType.TOKEN_EXCHANGE,
                 params = mapOf(
                     OAuth2ParameterNames.SUBJECT_TOKEN_TYPE to "urn:ietf:params:oauth:token-type:jwt",
                     OAuth2ParameterNames.SUBJECT_TOKEN to token,
@@ -85,7 +85,7 @@ data class GrantRequest(
 
         fun onBehalfOf(token: String, scope: String): GrantRequest =
             GrantRequest(
-                grantType = OAuth2GrantType.JWT_BEARER,
+                grantType = GrantType.JWT_BEARER,
                 params = mapOf(
                     OAuth2ParameterNames.SCOPE to scope,
                     OAuth2ParameterNames.REQUESTED_TOKEN_USE to "on_behalf_of",
@@ -95,7 +95,7 @@ data class GrantRequest(
 
         fun clientCredentials(scope: String): GrantRequest =
             GrantRequest(
-                grantType = OAuth2GrantType.CLIENT_CREDENTIALS,
+                grantType = GrantType.CLIENT_CREDENTIALS,
                 params = mapOf(
                     OAuth2ParameterNames.SCOPE to scope,
                 )

--- a/token-client-spring/src/test/kotlin/no/nav/security/token/support/client/spring/oauth2/OAuth2AccessTokenServiceIntegrationTest.kt
+++ b/token-client-spring/src/test/kotlin/no/nav/security/token/support/client/spring/oauth2/OAuth2AccessTokenServiceIntegrationTest.kt
@@ -3,7 +3,7 @@ package no.nav.security.token.support.client.spring.oauth2
 import com.nimbusds.jwt.JWT
 import com.nimbusds.jwt.JWTClaimsSet.Builder
 import com.nimbusds.jwt.PlainJWT
-import no.nav.security.token.support.client.core.OAuth2GrantType
+import com.nimbusds.oauth2.sdk.GrantType
 import no.nav.security.token.support.client.core.context.JwtBearerTokenResolver
 import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenService
 import no.nav.security.token.support.client.spring.ClientConfigurationProperties
@@ -61,10 +61,8 @@ internal class OAuth2AccessTokenServiceIntegrationTest {
         server!!.shutdown()
     }
 
-    @get:Throws(InterruptedException::class)
-    @get:Test
-    val accessTokenOnBehalfOf: Unit
-        get() {
+    @Test
+    fun accessTokenOnBehalfOf() {
             var clientProperties = clientConfigurationProperties.registration["example1-onbehalfof"]
             Assertions.assertThat(clientProperties).isNotNull
             clientProperties = clientProperties!!.toBuilder()
@@ -89,7 +87,7 @@ internal class OAuth2AccessTokenServiceIntegrationTest {
             Assertions.assertThat(usernamePwd).isEqualTo(auth.clientId + ":" + auth.clientSecret)
             Assertions.assertThat(body).contains(
                 "grant_type=" + URLEncoder.encode(
-                    OAuth2GrantType.JWT_BEARER.value,
+                    GrantType.JWT_BEARER.value,
                     StandardCharsets.UTF_8))
             Assertions.assertThat(body).contains(
                 "scope=" + URLEncoder.encode(
@@ -103,10 +101,8 @@ internal class OAuth2AccessTokenServiceIntegrationTest {
             Assertions.assertThat(response?.expiresIn).isGreaterThan(0)
         }
 
-    @get:Throws(InterruptedException::class)
-    @get:Test
-    val accessTokenUsingTokenExhange: Unit
-        get() {
+    @Test
+    fun accessTokenUsingTokenExhange() {
             var clientProperties = clientConfigurationProperties.registration["example1-token" +
                 "-exchange1"]
             Assertions.assertThat(clientProperties).isNotNull
@@ -123,7 +119,7 @@ internal class OAuth2AccessTokenServiceIntegrationTest {
             Assertions.assertThat(headers["Content-Type"]).contains("application/x-www-form-urlencoded")
             Assertions.assertThat(body).contains(
                 "grant_type=" + URLEncoder.encode(
-                    OAuth2GrantType.TOKEN_EXCHANGE.value,
+                    GrantType.TOKEN_EXCHANGE.value,
                     StandardCharsets.UTF_8))
             Assertions.assertThat(body).contains("subject_token=" + assertionResolver.token().orElse(null))
             Assertions.assertThat(response).isNotNull
@@ -132,10 +128,8 @@ internal class OAuth2AccessTokenServiceIntegrationTest {
             Assertions.assertThat(response?.expiresIn).isGreaterThan(0)
         }
 
-    @get:Throws(InterruptedException::class)
-    @get:Test
-    val accessTokenClientCredentials: Unit
-        get() {
+    @Test
+    fun accessTokenClientCredentials() {
             var clientProperties = clientConfigurationProperties.registration["example1-clientcredentials1"]
             Assertions.assertThat(clientProperties).isNotNull
             clientProperties = clientProperties!!.toBuilder()


### PR DESCRIPTION
 OAuth2GrantType duplicates constants already on the classpath via Nimbus. Will eventually be removed