### PR TITLE
Potential fix for code scanning alert no. 115: Insertion of sensitive information into log files

### DIFF
--- a/token-validation-filter/src/main/kotlin/no/nav/security/token/support/filter/JwtTokenExpiryFilter.kt
+++ b/token-validation-filter/src/main/kotlin/no/nav/security/token/support/filter/JwtTokenExpiryFilter.kt
@@ -43,7 +43,7 @@ class JwtTokenExpiryFilter(private val contextHolder : TokenValidationContextHol
 
     private fun addHeaderOnTokenExpiryThreshold(response : HttpServletResponse) {
         val tokenValidationContext = contextHolder.getTokenValidationContext()
-        LOG.debug("Getting TokenValidationContext: {}", tokenValidationContext)
+        LOG.debug("Got TokenValidationContext")
         if (tokenValidationContext != null) {
             LOG.debug("Getting issuers from validationcontext {}", tokenValidationContext.issuers)
             for (issuer in tokenValidationContext.issuers) {


### PR DESCRIPTION
Potential fix for [https://github.com/navikt/token-support/security/code-scanning/115](https://github.com/navikt/token-support/security/code-scanning/115)

To resolve the issue, avoid logging the entire `TokenValidationContext` object. Only log non-sensitive metadata if needed (e.g., log that a context was found, but not its content).  
- Specifically, in `addHeaderOnTokenExpiryThreshold`, remove or revise line 46 so that it does not log the full context object.
- Instead, consider logging a simple message, such as "Got TokenValidationContext" if you need to keep a trace in the debug logs.  
- No changes to other logic or imports are required.  
- No changes are needed elsewhere unless other similar logging occurs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
