### PR TITLE
Potential fix for code scanning alert no. 121: Implicit conversion from array to string

### DIFF
--- a/token-validation-ktor-v3/src/main/kotlin/no/nav/security/token/support/v3/TokenSupportAuthenticationProvider.kt
+++ b/token-validation-ktor-v3/src/main/kotlin/no/nav/security/token/support/v3/TokenSupportAuthenticationProvider.kt
@@ -124,7 +124,7 @@ internal class RequiredClaimsHandler(private val tokenValidationContextHolder: T
                     throw JwtTokenMissingException("No valid token found in validation context")
                 }
                 if (!handleProtectedWithClaims(issuer, claimMap, combineWithOr, jwtToken.get()))
-                    throw JwtTokenInvalidClaimException("Required claims not present in token." + requiredClaims.claimMap)
+                    throw JwtTokenInvalidClaimException("Required claims not present in token. " + requiredClaims.claimMap.entries.joinToString())
             }
         }.getOrElse {  e -> throw RequiredClaimsException(e.message ?: "", e) }
     }


### PR DESCRIPTION
Potential fix for [https://github.com/navikt/token-support/security/code-scanning/121](https://github.com/navikt/token-support/security/code-scanning/121)

The best way to fix this problem is to ensure that when converting `requiredClaims.claimMap` to a string, an explicit conversion is used to produce a human-readable format. For arrays, use `Arrays.toString` (or `Arrays.deepToString` for nested arrays). For Kotlin collections or maps, use `.toString()`, `.entries.joinToString()`, or otherwise format the collection in a way that reveals its contents. 

Specifically for the current code, we should update line 127, changing:
```kt
throw JwtTokenInvalidClaimException("Required claims not present in token." + requiredClaims.claimMap)
```
to something like:
```kt
throw JwtTokenInvalidClaimException("Required claims not present in token. " + requiredClaims.claimMap.entries.joinToString())
```
This change will ensure that the map content is properly displayed, assuming `claimMap` is a `Map`. If it is actually an array, we would use `Arrays.toString(claimMap)`. Since we can only see the current snippet, and typical usage for "claims" is to use a `Map`, we'll use `.entries.joinToString()`.

No additional imports are needed if the type is a Kotlin Map; if it were a Java array, we would need to import `java.util.Arrays`. For safety, ensure that the fix works for the actual type and yields readable output.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
